### PR TITLE
Add /missions endpoint to list available missions

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,9 +311,6 @@ Example Response:
     "missions": [
         {
             "slug": "mission-1",
-            "name": "Mission 1",
-            "description": "Drive to the checkpoints in order",
-            "type": "checkpoints",
             "distance_in_m": 120.5,
             "checkpoints_count": 3
         }

--- a/README.md
+++ b/README.md
@@ -294,6 +294,33 @@ If you just want to experiment with the bot without starting a mission you need 
 
 `Note: Bots that are controlled by other players are not available for missions.`
 
+### GET /missions
+
+Lists the available missions for the bot you are connected to (the one set in `BOT_SLUG`). You don't need to start a mission to call this endpoint. Use the returned `slug` as the `MISSION_SLUG` environment variable to start a mission.
+
+`Note: Missions are only listed for remote bots (the deployed Earth Rovers you drive remotely). Personal bots do not have missions, so this endpoint will return an empty list for them.`
+
+```bash
+curl --location 'http://localhost:8000/missions'
+```
+
+Example Response:
+
+```JSON
+{
+    "missions": [
+        {
+            "slug": "mission-1",
+            "name": "Mission 1",
+            "description": "Drive to the checkpoints in order",
+            "type": "checkpoints",
+            "distance_in_m": 120.5,
+            "checkpoints_count": 3
+        }
+    ]
+}
+```
+
 ### POST /start-mission
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <br>
 </p>
 
-# Earth Rovers SDK v5.1
+# Earth Rovers SDK v5.2
 
 ## Requirements
 
@@ -530,6 +530,12 @@ Example Response:
 ```
 
 # Latest updates
+
+- v.5.2:
+
+  - Added `/missions` endpoint to list the available missions for the connected bot
+  - No active mission is required; the returned `slug` can be used as `MISSION_SLUG` to start a mission
+  - Missions are only listed for remote bots (personal bots return an empty list)
 
 - v.5.1:
 

--- a/main.py
+++ b/main.py
@@ -603,7 +603,16 @@ async def missions():
                 detail="Failed to retrieve missions",
             )
 
-        return JSONResponse(content=response.json())
+        missions_list = [
+            {
+                "slug": mission.get("slug"),
+                "distance_in_m": mission.get("distance_in_m"),
+                "checkpoints_count": mission.get("checkpoints_count"),
+            }
+            for mission in response.json().get("missions", [])
+        ]
+
+        return JSONResponse(content={"missions": missions_list})
     except requests.RequestException as e:
         raise HTTPException(
             status_code=500, detail=f"Error fetching missions: {str(e)}"

--- a/main.py
+++ b/main.py
@@ -570,6 +570,46 @@ async def missions_history():
         )
 
 
+@app.get("/missions")
+async def missions():
+    auth_header = os.getenv("SDK_API_TOKEN")
+    bot_slug = os.getenv("BOT_SLUG")
+
+    if not auth_header:
+        raise HTTPException(
+            status_code=500, detail="Authorization header not configured"
+        )
+    if not bot_slug:
+        raise HTTPException(status_code=500, detail="Bot name not configured")
+
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {auth_header}",
+    }
+
+    payload = {"bot_slug": bot_slug}
+
+    try:
+        response = requests.get(
+            FRODOBOTS_API_URL + "/sdk/missions",
+            headers=headers,
+            params=payload,
+            timeout=15,
+        )
+
+        if response.status_code != 200:
+            raise HTTPException(
+                status_code=response.status_code,
+                detail="Failed to retrieve missions",
+            )
+
+        return JSONResponse(content=response.json())
+    except requests.RequestException as e:
+        raise HTTPException(
+            status_code=500, detail=f"Error fetching missions: {str(e)}"
+        )
+
+
 @app.get("/v2/screenshot")
 async def get_screenshot_v2():
     await need_start_mission()


### PR DESCRIPTION
## Summary
Adds a `GET /missions` endpoint that lists the available missions for the connected bot (`BOT_SLUG`).

- Does **not** require `MISSION_SLUG` or an active ride/mission.
- Proxies to the API's `GET /sdk/missions` using `SDK_API_TOKEN` + `BOT_SLUG`.
- The returned `slug` can be set as `MISSION_SLUG` to start a mission via `/start-mission`.
- README documents the endpoint and clarifies missions are only listed for remote bots (personal bots return an empty list).

Requires the companion API PR: frodobots-org/frodobots_web#feature/sdk-missions-endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)