### PR TITLE
v6.2: Reliable /v2 polling for ROS — warm capture cache, immediate fail-fast, benchmarks

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,6 +5,14 @@ MAP_ZOOM_LEVEL=18
 IMAGE_FORMAT="jpeg"
 IMAGE_QUALITY="0.8"
 FEED_JPEG_QUALITY="0.8"
+# How long the shared capture loop keeps running after the last /feed client
+# or /v2 snapshot poll, so steady polling always hits a warm frame cache.
+# Default: 10
+# FEED_IDLE_LINGER_S=10
+# How long /v2/front|rear|screenshot waits for a fresh frame before failing
+# fast with 404/503 (a healthy camera answers in tens of milliseconds).
+# Default: 2
+# V2_FRAME_TIMEOUT_S=2
 # Optional: Playwright manages its own Chromium. Set this only to use a
 # specific browser binary (e.g. real Google Chrome for H.264 streams).
 # CHROME_EXECUTABLE_PATH="/path/to/chrome"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <br>
 </p>
 
-# Earth Rovers SDK v6.1
+# Earth Rovers SDK v6.2
 
 ## Requirements
 
@@ -677,6 +677,13 @@ Example Response:
 ```
 
 # Latest updates
+
+- v.6.2:
+
+  - **Reliable `/v2` polling for ROS 2**: the shared camera capture stays warm between snapshot requests, so steady 10 Hz pollers no longer restart capture on every tick
+  - Capture failures return an immediate, actionable `503` while recovery backoff continues in the background; snapshot callers never wait inside that backoff
+  - `/v2` capture is bounded by `V2_FRAME_TIMEOUT_S` for every configured image format, and `/status` exposes per-camera capture health and failure counters
+  - Added plain-Python and ROS 2 Humble polling benchmarks with complete latency accounting (including failed requests), duplicate-frame detection, and missed-tick dropping
 
 - v.6.1:
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ IMAGE_QUALITY=0.8
 IMAGE_FORMAT=jpeg
 # Dedicated MJPEG feed quality (always JPEG; default: 0.8)
 FEED_JPEG_QUALITY=0.8
+# Seconds the shared capture loop stays warm after the last /feed client or
+# /v2 snapshot poll (default: 10)
+# FEED_IDLE_LINGER_S=10
+# Seconds /v2/* waits for a fresh frame before failing fast (default: 2)
+# V2_FRAME_TIMEOUT_S=2
 # TTS Provider: "edge" (free, default) or "gemini"
 TTS_PROVIDER=edge
 # API key (required for gemini only)
@@ -249,7 +254,11 @@ Example Response:
 
 This endpoint returns fresh cached camera frames as base64 with their actual capture timestamps. The rear camera is detected automatically: if the bot publishes a rear stream (e.g. Mini+, Zero), the response includes `rear_frame`; single-camera bots return only the front. The legacy `timestamp` field is the newest capture, while `front_timestamp` and `rear_timestamp` identify each frame precisely.
 
+Polling this endpoint at a steady rate (e.g. 10 Hz from a ROS node) is fully supported: the shared capture loop stays warm between polls (`FEED_IDLE_LINGER_S`, default 10 s), so each request returns a fresh, distinct frame in tens of milliseconds. If a fresh frame can't be produced within `V2_FRAME_TIMEOUT_S` (default 2 s) the endpoint fails fast — 503 with the capture error when known, 404 otherwise — instead of stalling; keep polling and it recovers as soon as the camera does.
+
 You can parametrize the image quality between 0.1 and 1.0, and the format between jpeg, png and webp, using the IMAGE_QUALITY and IMAGE_FORMAT environment variables.
+
+> **Performance trap**: `/v2/*` shares the warm frame cache with `/feed` only in the default configuration (`IMAGE_FORMAT=jpeg` with `IMAGE_QUALITY` equal to `FEED_JPEG_QUALITY`). Setting a different format or quality silently switches `/v2/*` to an uncached per-request capture path, which is significantly slower under polling. If you poll for frames, keep the defaults.
 
 ```bash
 curl --location 'http://localhost:8000/v2/screenshot'
@@ -381,13 +390,30 @@ Sample Response:
   "browser_ready": true,
   "mission_started": true,
   "ingest_connected": true,
-  "telemetry_age_s": 0.42
+  "telemetry_age_s": 0.42,
+  "video": {
+    "front": {
+      "loop_running": true,
+      "latest_frame_age_s": 0.03,
+      "captures_total": 18240,
+      "failures_total": 2,
+      "last_error": null
+    },
+    "rear": {
+      "loop_running": false,
+      "latest_frame_age_s": null,
+      "captures_total": 0,
+      "failures_total": 0,
+      "last_error": null
+    }
+  }
 }
 ```
 
 - `browser_ready`: the headless browser is connected to the rover's channel
 - `ingest_connected`: telemetry is flowing from the rover into the SDK
 - `telemetry_age_s`: seconds since the last telemetry message (`null` if none yet)
+- `video.<camera>`: frame-capture pipeline health per camera — whether the shared capture loop is currently running, the age of the newest cached frame, capture/failure counters since startup, and the most recent capture error (`null` when healthy). Useful for correlating client-side frame latency spikes with server-side capture failures.
 
 ### WS /ws/data
 

--- a/browser_service.py
+++ b/browser_service.py
@@ -39,6 +39,10 @@ class BrowserService:
         self._lock = None
         self._lock_loop = None
         self.last_error = None
+        # has_rear_camera() cache: (value, monotonic expiry). A positive
+        # result holds for the page's lifetime; a negative one only briefly,
+        # since the rear track can subscribe late after the Agora join.
+        self._rear_camera: Optional[tuple[bool, float]] = None
         # Large enough for the legacy front/rear/map element captures without
         # paying for an 8.3-megapixel headless render surface on every frame.
         self._viewport = {"width": 1920, "height": 1200}
@@ -167,6 +171,7 @@ class BrowserService:
 
     async def _teardown(self):
         self._ready = False
+        self._rear_camera = None
         for target in (self._page, self._context, self._browser):
             if target:
                 try:
@@ -267,14 +272,21 @@ class BrowserService:
 
     async def has_rear_camera(self) -> bool:
         # Capability comes from reality, not BOT_TYPE: the rover either
-        # publishes a rear video track (uid 1001) or it doesn't.
-        result = await self._run(
-            lambda page: page.evaluate(
-                "() => !!(typeof remoteUsers !== 'undefined'"
-                " && remoteUsers[1001] && remoteUsers[1001].videoTrack)"
+        # publishes a rear video track (uid 1001) or it doesn't. Cached so
+        # frame polling doesn't pay a page round trip on every request.
+        cached = self._rear_camera
+        if cached and (cached[0] or time.monotonic() < cached[1]):
+            return cached[0]
+        result = bool(
+            await self._run(
+                lambda page: page.evaluate(
+                    "() => !!(typeof remoteUsers !== 'undefined'"
+                    " && remoteUsers[1001] && remoteUsers[1001].videoTrack)"
+                )
             )
         )
-        return bool(result)
+        self._rear_camera = (result, time.monotonic() + 5)
+        return result
 
     async def front(self) -> str:
         return await self._run(

--- a/examples/benchmarks/latency_probe.py
+++ b/examples/benchmarks/latency_probe.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Frame-latency probe for the Earth Rovers SDK.
+
+Measures what a researcher's polling client actually experiences, without ROS
+or Docker in the way:
+
+  v2_front       GET /v2/front at a fixed rate, wall time per request
+  v2_screenshot  GET /v2/screenshot at a fixed rate, wall time per request
+  feed           GET /feed MJPEG stream, inter-frame arrival gaps
+
+Prints one line per sample (er_driver's format, so runs are directly
+comparable with researcher logs), a rolling summary every 30 s, and a final
+summary on Ctrl-C. Optionally dumps per-sample rows to CSV for before/after
+comparison.
+
+Usage:
+    python3 examples/benchmarks/latency_probe.py --mode v2_front --rate 10
+    python3 examples/benchmarks/latency_probe.py --mode feed --fps 15 \
+        --csv baseline_feed.csv
+"""
+
+import argparse
+import csv
+import signal
+import sys
+import time
+
+import requests
+
+SUMMARY_INTERVAL_S = 30.0
+
+
+class Stats:
+    def __init__(self, label: str):
+        self.label = label
+        self.samples: list[float] = []
+        self.errors: dict[str, int] = {}
+        self.empty = 0
+        self.duplicate_timestamps = 0
+        self._last_frame_timestamp = None
+        self.started = time.monotonic()
+
+    def record(self, seconds: float, frame_timestamp=None):
+        self.samples.append(seconds)
+        if frame_timestamp is not None:
+            if frame_timestamp == self._last_frame_timestamp:
+                self.duplicate_timestamps += 1
+            self._last_frame_timestamp = frame_timestamp
+
+    def record_error(self, kind: str):
+        self.errors[kind] = self.errors.get(kind, 0) + 1
+
+    @staticmethod
+    def _percentile(ordered: list[float], fraction: float) -> float:
+        index = min(len(ordered) - 1, max(0, round(fraction * (len(ordered) - 1))))
+        return ordered[index]
+
+    def summary(self) -> str:
+        elapsed = time.monotonic() - self.started
+        if not self.samples:
+            return f"[{self.label}] no samples in {elapsed:.0f}s, errors={self.errors}"
+        ordered = sorted(self.samples)
+        lines = [
+            f"[{self.label}] {len(ordered)} samples over {elapsed:.0f}s",
+            f"  p50={self._percentile(ordered, 0.50):.4f}s"
+            f"  p90={self._percentile(ordered, 0.90):.4f}s"
+            f"  p99={self._percentile(ordered, 0.99):.4f}s"
+            f"  max={ordered[-1]:.4f}s",
+            f"  >0.5s: {sum(1 for s in ordered if s > 0.5)}"
+            f"  >1s: {sum(1 for s in ordered if s > 1.0)}"
+            f"  duplicate_timestamps: {self.duplicate_timestamps}"
+            f"  empty: {self.empty}",
+        ]
+        if self.errors:
+            lines.append(f"  errors: {self.errors}")
+        return "\n".join(lines)
+
+
+def open_csv(path):
+    handle = open(path, "w", newline="")
+    writer = csv.writer(handle)
+    writer.writerow(["wall_time", "seconds", "status", "frame_timestamp"])
+    return handle, writer
+
+
+def poll_v2(args, stats: Stats, writer):
+    """Fixed-rate polling with deadline pacing (a late request does not shift
+    the schedule, matching how a ROS timer fires)."""
+    endpoint = "/v2/front" if args.mode == "v2_front" else "/v2/screenshot"
+    frame_key = "front_frame"
+    url = args.sdk_url.rstrip("/") + endpoint
+    session = requests.Session() if args.session else requests
+    interval = 1.0 / args.rate
+    deadline = time.monotonic()
+    while True:
+        started = time.monotonic()
+        status, frame_timestamp = "exc", None
+        try:
+            response = session.get(url, timeout=args.timeout)
+            status = str(response.status_code)
+            elapsed = time.monotonic() - started
+            if response.status_code == 200:
+                body = response.json()
+                frame_timestamp = body.get("timestamp")
+                if not body.get(frame_key):
+                    stats.empty += 1
+                    print(f"Image (SDK): {elapsed:.6f}  [empty body]", flush=True)
+                else:
+                    print(f"Image (SDK): {elapsed:.6f}", flush=True)
+                stats.record(elapsed, frame_timestamp)
+            else:
+                stats.record_error(status)
+                detail = response.text[:120].replace("\n", " ")
+                print(
+                    f"Image (SDK): {elapsed:.6f}  [ERROR] No image data in response"
+                    f" (HTTP {status}: {detail})",
+                    flush=True,
+                )
+        except requests.RequestException as exc:
+            elapsed = time.monotonic() - started
+            stats.record_error(type(exc).__name__)
+            print(f"Image (SDK): {elapsed:.6f}  [EXC] {exc}", flush=True)
+        if writer:
+            writer.writerow([time.time(), f"{elapsed:.6f}", status, frame_timestamp])
+
+        deadline += interval
+        sleep = deadline - time.monotonic()
+        if sleep > 0:
+            time.sleep(sleep)
+        else:
+            deadline = time.monotonic()  # fell behind: reset, don't burst
+
+
+def stream_feed(args, stats: Stats, writer):
+    """Consume the MJPEG stream and measure inter-frame arrival gaps."""
+    url = f"{args.sdk_url.rstrip('/')}/feed?view=front&fps={args.fps}"
+    boundary = b"--frame"
+    while True:
+        try:
+            with requests.get(url, stream=True, timeout=(5, args.timeout)) as response:
+                if response.status_code != 200:
+                    stats.record_error(str(response.status_code))
+                    print(f"/feed HTTP {response.status_code}: {response.text[:120]}")
+                    time.sleep(2)
+                    continue
+                print(f"Connected to {url}")
+                previous = None
+                buffer = b""
+                for chunk in response.iter_content(chunk_size=16384):
+                    buffer += chunk
+                    while True:
+                        start = buffer.find(boundary)
+                        next_part = buffer.find(boundary, start + len(boundary))
+                        if start < 0 or next_part < 0:
+                            break
+                        buffer = buffer[next_part:]
+                        now = time.monotonic()
+                        if previous is not None:
+                            gap = now - previous
+                            print(f"Frame gap: {gap:.6f}", flush=True)
+                            stats.record(gap)
+                            if writer:
+                                writer.writerow(
+                                    [time.time(), f"{gap:.6f}", "frame", ""]
+                                )
+                        previous = now
+        except requests.RequestException as exc:
+            stats.record_error(type(exc).__name__)
+            print(f"/feed error, reconnecting: {exc}")
+            time.sleep(2)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sdk-url", default="http://localhost:8000", help="SDK base URL"
+    )
+    parser.add_argument(
+        "--mode", choices=["v2_front", "v2_screenshot", "feed"], default="v2_front"
+    )
+    parser.add_argument("--rate", type=float, default=10.0, help="poll rate (Hz)")
+    parser.add_argument("--fps", type=int, default=15, help="feed mode: requested fps")
+    parser.add_argument(
+        "--timeout", type=float, default=10.0, help="HTTP timeout (generous on"
+        " purpose: we want to observe server stalls, not clip them)"
+    )
+    parser.add_argument(
+        "--no-session", dest="session", action="store_false",
+        help="new TCP connection per request instead of a reused Session",
+    )
+    parser.add_argument("--csv", help="dump per-sample rows to this CSV file")
+    parser.add_argument(
+        "--duration", type=float, default=0,
+        help="stop after N seconds (default: run until Ctrl-C)",
+    )
+    args = parser.parse_args()
+
+    stats = Stats(args.mode)
+    handle, writer = (None, None)
+    if args.csv:
+        handle, writer = open_csv(args.csv)
+
+    def finish(*_):
+        print("\n" + stats.summary())
+        if handle:
+            handle.close()
+            print(f"CSV written to {args.csv}")
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, finish)
+    signal.signal(signal.SIGTERM, finish)
+    if args.duration:
+        signal.signal(signal.SIGALRM, finish)
+        signal.setitimer(signal.ITIMER_REAL, args.duration)
+
+    def periodic_summary():
+        print(stats.summary(), flush=True)
+
+    # Piggyback the rolling summary on SIGALRM only when no duration is set;
+    # otherwise print it from the sampling loops via a simple time check.
+    last_summary = time.monotonic()
+    original_record = stats.record
+
+    def record_with_summary(seconds, frame_timestamp=None):
+        nonlocal last_summary
+        original_record(seconds, frame_timestamp)
+        if time.monotonic() - last_summary >= SUMMARY_INTERVAL_S:
+            last_summary = time.monotonic()
+            periodic_summary()
+
+    stats.record = record_with_summary
+
+    try:
+        if args.mode == "feed":
+            stream_feed(args, stats, writer)
+        else:
+            poll_v2(args, stats, writer)
+    except KeyboardInterrupt:
+        finish()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/benchmarks/latency_probe.py
+++ b/examples/benchmarks/latency_probe.py
@@ -84,8 +84,7 @@ def open_csv(path):
 
 
 def poll_v2(args, stats: Stats, writer):
-    """Fixed-rate polling with deadline pacing (a late request does not shift
-    the schedule, matching how a ROS timer fires)."""
+    """Fixed-rate polling with deadline pacing and missed-tick dropping."""
     endpoint = "/v2/front" if args.mode == "v2_front" else "/v2/screenshot"
     frame_key = "front_frame"
     url = args.sdk_url.rstrip("/") + endpoint
@@ -109,6 +108,10 @@ def poll_v2(args, stats: Stats, writer):
                     print(f"Image (SDK): {elapsed:.6f}", flush=True)
                 stats.record(elapsed, frame_timestamp)
             else:
+                # Error responses are still completed requests and must count
+                # toward latency percentiles; excluding them can hide the exact
+                # slow-failure spikes this probe is intended to detect.
+                stats.record(elapsed)
                 stats.record_error(status)
                 detail = response.text[:120].replace("\n", " ")
                 print(
@@ -118,6 +121,7 @@ def poll_v2(args, stats: Stats, writer):
                 )
         except requests.RequestException as exc:
             elapsed = time.monotonic() - started
+            stats.record(elapsed)
             stats.record_error(type(exc).__name__)
             print(f"Image (SDK): {elapsed:.6f}  [EXC] {exc}", flush=True)
         if writer:
@@ -128,7 +132,11 @@ def poll_v2(args, stats: Stats, writer):
         if sleep > 0:
             time.sleep(sleep)
         else:
-            deadline = time.monotonic()  # fell behind: reset, don't burst
+            # Fell behind: drop missed ticks and wait a full interval. Starting
+            # the next request immediately would be a one-request burst and can
+            # return the same fresh cached frame as the slow request.
+            deadline = time.monotonic() + interval
+            time.sleep(interval)
 
 
 def stream_feed(args, stats: Stats, writer):

--- a/examples/ros2/Dockerfile
+++ b/examples/ros2/Dockerfile
@@ -1,0 +1,22 @@
+# ROS 2 environment for the Earth Rovers SDK examples, for hosts without a
+# native ROS install (macOS, Windows). The SDK server itself stays on the
+# host — reach it from inside the container at http://host.docker.internal:8000.
+#
+#   docker build -t er-ros2 examples/ros2
+#   docker run -it --rm -v "$PWD/examples/ros2:/ws" er-ros2 \
+#     python3 /ws/er_poll_benchmark.py --ros-args \
+#       -p sdk_url:=http://host.docker.internal:8000
+FROM ros:humble
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ros-humble-cv-bridge \
+        python3-opencv \
+        python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# requests ships with the base image; websocket-client is for the bridge's
+# /ws/data telemetry loop.
+RUN pip3 install --no-cache-dir requests websocket-client
+
+WORKDIR /ws

--- a/examples/ros2/README.md
+++ b/examples/ros2/README.md
@@ -36,6 +36,22 @@ Requires a ROS2 distro (Humble or newer recommended) with `rclpy` and
 pip install requests websocket-client opencv-python
 ```
 
+### No ROS on your machine? (macOS / Windows)
+
+Native ROS2 isn't practical outside Linux — use the provided Docker image
+instead. The SDK server stays on the host; the container reaches it at
+`host.docker.internal`:
+
+```bash
+docker build -t er-ros2 examples/ros2
+docker run -it --rm -v "$PWD/examples/ros2:/ws" er-ros2 \
+  python3 /ws/earth_rover_bridge.py --ros-args \
+    -p sdk_url:=http://host.docker.internal:8000
+```
+
+(Don't use `--network host` on macOS/Windows — Docker runs in a VM there, so
+host networking doesn't reach the host's `localhost`.)
+
 ## Run
 
 1. Start the SDK (and the mission, if you use one):
@@ -71,3 +87,42 @@ cap = cv2.VideoCapture("http://localhost:8000/feed?view=front&fps=15")
 while True:
     ok, frame = cap.read()
 ```
+
+## Polling `/v2` from ROS — known-good pattern
+
+Prefer `/feed` (above) for continuous video: frames are pushed as they're
+captured, with no per-frame HTTP overhead. If your pipeline needs
+request/response polling instead, `/v2/front` at a steady rate is supported —
+the SDK keeps the capture loop warm between polls — as long as the client
+follows three rules:
+
+1. **Reuse one `requests.Session()`** (connection reuse; no TCP+TLS handshake
+   per frame).
+2. **Pace with a deadline, not `sleep(interval)`**, so a slow request doesn't
+   shift the schedule.
+3. **Treat 404/503 as "skip this tick"**: during a transient camera blip the
+   SDK fails fast (within `V2_FRAME_TIMEOUT_S`, default 2 s) rather than
+   stalling; the next polls succeed once capture recovers.
+
+`er_poll_benchmark.py` in this directory implements exactly that and doubles
+as a diagnostic: it logs each request's wall time (`Image (SDK): <seconds>`),
+publishes the frames as `sensor_msgs/CompressedImage`, and prints rolling
+p50/p90/p99/max latency summaries with error counts:
+
+```bash
+# poll /v2/front at 10 Hz (inside the Docker container: use host.docker.internal)
+python3 er_poll_benchmark.py --ros-args \
+  -p sdk_url:=http://localhost:8000 -p mode:=v2_front -p rate_hz:=10.0
+
+# same measurement for the MJPEG feed (inter-frame arrival gaps)
+python3 er_poll_benchmark.py --ros-args \
+  -p sdk_url:=http://localhost:8000 -p mode:=feed -p feed_fps:=15
+
+# dump per-request rows for before/after comparison
+python3 er_poll_benchmark.py --ros-args \
+  -p sdk_url:=http://localhost:8000 -p csv_path:=/ws/latency.csv
+```
+
+If you see latency spikes with this node, check `GET /status` → `video`:
+`failures_total` climbing and `last_error` tell you the server-side capture
+(not your client or ROS) is the bottleneck.

--- a/examples/ros2/earth_rover_bridge.py
+++ b/examples/ros2/earth_rover_bridge.py
@@ -263,7 +263,9 @@ def main(args=None):
         pass
     finally:
         node.destroy_node()
-        rclpy.shutdown()
+        # ROS signal handling may already have shut the context down.
+        if rclpy.ok():
+            rclpy.shutdown()
 
 
 if __name__ == "__main__":

--- a/examples/ros2/er_poll_benchmark.py
+++ b/examples/ros2/er_poll_benchmark.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""ROS2 frame-acquisition benchmark for the Earth Rovers SDK.
+
+Replicates the pattern researchers use — polling the SDK's snapshot
+endpoints at a fixed rate from a ROS node — and measures what that client
+actually experiences: per-request wall time (logged in the familiar
+`Image (SDK): <seconds>` format), rolling percentiles, error counts, and an
+optional CSV for before/after comparison. Also supports consuming the MJPEG
+/feed stream, measuring inter-frame arrival gaps, for an apples-to-apples
+comparison of the two integration styles.
+
+Frames are published as sensor_msgs/CompressedImage (JPEG bytes straight
+from the SDK, no decode), so the node needs no cv_bridge/OpenCV.
+
+Usage (SDK running on the host, node inside the ros:humble container):
+    python3 er_poll_benchmark.py --ros-args \
+        -p sdk_url:=http://host.docker.internal:8000 \
+        -p mode:=v2_front -p rate_hz:=10.0
+
+    # /feed comparison at 15 fps:
+    python3 er_poll_benchmark.py --ros-args \
+        -p sdk_url:=http://host.docker.internal:8000 -p mode:=feed
+
+Parameters:
+    sdk_url        SDK base URL (default http://localhost:8000)
+    mode           v2_front | v2_screenshot | feed (default v2_front)
+    rate_hz        poll rate for v2 modes (default 10.0)
+    feed_fps       requested fps for feed mode (default 15)
+    use_session    reuse one TCP connection (default True; False opens a new
+                   connection per request, like a naive client)
+    http_timeout_s per-request timeout, generous on purpose so server stalls
+                   are observed rather than clipped (default 10.0)
+    csv_path       write per-sample rows to this file (default: disabled)
+
+Dependencies: rclpy + requests (both present in the ros:humble image).
+"""
+
+import base64
+import csv
+import threading
+import time
+
+import rclpy
+import requests
+from rclpy.node import Node
+from rclpy.qos import HistoryPolicy, QoSProfile, ReliabilityPolicy
+from sensor_msgs.msg import CompressedImage
+
+SUMMARY_INTERVAL_S = 30.0
+
+
+class Stats:
+    def __init__(self):
+        self.samples = []
+        self.errors = {}
+        self.empty = 0
+        self.duplicate_timestamps = 0
+        self._last_frame_timestamp = None
+        self.started = time.monotonic()
+        self.lock = threading.Lock()
+
+    def record(self, seconds, frame_timestamp=None):
+        with self.lock:
+            self.samples.append(seconds)
+            if frame_timestamp is not None:
+                if frame_timestamp == self._last_frame_timestamp:
+                    self.duplicate_timestamps += 1
+                self._last_frame_timestamp = frame_timestamp
+
+    def record_error(self, kind):
+        with self.lock:
+            self.errors[kind] = self.errors.get(kind, 0) + 1
+
+    @staticmethod
+    def _percentile(ordered, fraction):
+        index = min(len(ordered) - 1, max(0, round(fraction * (len(ordered) - 1))))
+        return ordered[index]
+
+    def summary(self):
+        with self.lock:
+            ordered = sorted(self.samples)
+            errors = dict(self.errors)
+            duplicates = self.duplicate_timestamps
+            empty = self.empty
+        elapsed = time.monotonic() - self.started
+        if not ordered:
+            return f"no samples in {elapsed:.0f}s, errors={errors}"
+        return (
+            f"{len(ordered)} samples over {elapsed:.0f}s | "
+            f"p50={self._percentile(ordered, 0.50):.4f}s "
+            f"p90={self._percentile(ordered, 0.90):.4f}s "
+            f"p99={self._percentile(ordered, 0.99):.4f}s "
+            f"max={ordered[-1]:.4f}s | "
+            f">0.5s: {sum(1 for s in ordered if s > 0.5)} "
+            f">1s: {sum(1 for s in ordered if s > 1.0)} | "
+            f"dup_timestamps: {duplicates} empty: {empty} errors: {errors}"
+        )
+
+
+class ErPollBenchmark(Node):
+    def __init__(self):
+        super().__init__("er_poll_benchmark")
+        self.declare_parameter("sdk_url", "http://localhost:8000")
+        self.declare_parameter("mode", "v2_front")
+        self.declare_parameter("rate_hz", 10.0)
+        self.declare_parameter("feed_fps", 15)
+        self.declare_parameter("use_session", True)
+        self.declare_parameter("http_timeout_s", 10.0)
+        self.declare_parameter("csv_path", "")
+
+        self.sdk_url = self.get_parameter("sdk_url").value.rstrip("/")
+        self.mode = self.get_parameter("mode").value
+        self.rate_hz = float(self.get_parameter("rate_hz").value)
+        self.feed_fps = int(self.get_parameter("feed_fps").value)
+        self.use_session = bool(self.get_parameter("use_session").value)
+        self.http_timeout_s = float(self.get_parameter("http_timeout_s").value)
+        self.csv_path = self.get_parameter("csv_path").value
+
+        if self.mode not in ("v2_front", "v2_screenshot", "feed"):
+            raise ValueError(f"invalid mode: {self.mode}")
+
+        sensor_qos = QoSProfile(
+            history=HistoryPolicy.KEEP_LAST,
+            depth=1,
+            reliability=ReliabilityPolicy.BEST_EFFORT,
+        )
+        self.image_pub = self.create_publisher(
+            CompressedImage, "earth_rover/front/image_raw/compressed", sensor_qos
+        )
+
+        self.stats = Stats()
+        self._csv_lock = threading.Lock()
+        self._csv_handle = None
+        self._csv = None
+        if self.csv_path:
+            self._csv_handle = open(self.csv_path, "w", newline="")
+            self._csv = csv.writer(self._csv_handle)
+            self._csv.writerow(["wall_time", "seconds", "status", "frame_timestamp"])
+
+        self._running = True
+        worker = self._feed_loop if self.mode == "feed" else self._poll_loop
+        threading.Thread(target=worker, daemon=True).start()
+        self.create_timer(SUMMARY_INTERVAL_S, self._log_summary)
+        self.get_logger().info(
+            f"Benchmarking {self.sdk_url} mode={self.mode} "
+            + (f"fps={self.feed_fps}" if self.mode == "feed"
+               else f"rate={self.rate_hz}Hz session={self.use_session}")
+        )
+
+    def _log_summary(self):
+        self.get_logger().info(f"[summary] {self.stats.summary()}")
+
+    def _write_csv(self, seconds, status, frame_timestamp):
+        if not self._csv:
+            return
+        with self._csv_lock:
+            self._csv.writerow(
+                [time.time(), f"{seconds:.6f}", status, frame_timestamp]
+            )
+
+    def _publish_jpeg(self, jpeg_bytes):
+        msg = CompressedImage()
+        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.header.frame_id = "earth_rover_front_camera"
+        msg.format = "jpeg"
+        msg.data = jpeg_bytes
+        self.image_pub.publish(msg)
+
+    # ------------------------------------------------------------- v2 poll
+
+    def _poll_loop(self):
+        endpoint = "/v2/front" if self.mode == "v2_front" else "/v2/screenshot"
+        url = self.sdk_url + endpoint
+        http = requests.Session() if self.use_session else requests
+        interval = 1.0 / self.rate_hz
+        deadline = time.monotonic()
+        while self._running and rclpy.ok():
+            started = time.monotonic()
+            status, frame_timestamp = "exc", None
+            elapsed = 0.0
+            try:
+                response = http.get(url, timeout=self.http_timeout_s)
+                status = str(response.status_code)
+                elapsed = time.monotonic() - started
+                if response.status_code == 200:
+                    body = response.json()
+                    frame = body.get("front_frame")
+                    frame_timestamp = body.get("timestamp")
+                    if frame:
+                        self.get_logger().info(f"Image (SDK): {elapsed:.6f}")
+                        self.stats.record(elapsed, frame_timestamp)
+                        self._publish_jpeg(base64.b64decode(frame))
+                    else:
+                        self.stats.empty += 1
+                        self.get_logger().error(
+                            f"No image data in response ({elapsed:.6f}s)"
+                        )
+                else:
+                    self.stats.record_error(status)
+                    self.get_logger().error(
+                        f"No image data in response "
+                        f"(HTTP {status}, {elapsed:.6f}s)"
+                    )
+            except requests.RequestException as exc:
+                elapsed = time.monotonic() - started
+                self.stats.record_error(type(exc).__name__)
+                self.get_logger().error(f"Request failed ({elapsed:.6f}s): {exc}")
+            self._write_csv(elapsed, status, frame_timestamp)
+
+            deadline += interval
+            wait = deadline - time.monotonic()
+            if wait > 0:
+                time.sleep(wait)
+            else:
+                deadline = time.monotonic()  # fell behind: reset, don't burst
+
+    # ---------------------------------------------------------------- feed
+
+    def _feed_loop(self):
+        url = f"{self.sdk_url}/feed?view=front&fps={self.feed_fps}"
+        while self._running and rclpy.ok():
+            try:
+                with requests.get(
+                    url, stream=True, timeout=(5, self.http_timeout_s)
+                ) as response:
+                    if response.status_code != 200:
+                        self.stats.record_error(str(response.status_code))
+                        self.get_logger().warning(
+                            f"/feed HTTP {response.status_code}, retrying in 2s"
+                        )
+                        time.sleep(2)
+                        continue
+                    self.get_logger().info(f"Connected to {url}")
+                    self._consume_mjpeg(response)
+            except requests.RequestException as exc:
+                self.stats.record_error(type(exc).__name__)
+                self.get_logger().warning(f"/feed reconnecting: {exc}")
+                time.sleep(2)
+
+    def _consume_mjpeg(self, response):
+        """Split the multipart stream on its boundary, timing frame arrivals."""
+        boundary = b"--frame"
+        buffer = b""
+        previous = None
+        for chunk in response.iter_content(chunk_size=16384):
+            if not (self._running and rclpy.ok()):
+                return
+            buffer += chunk
+            while True:
+                start = buffer.find(boundary)
+                next_part = buffer.find(boundary, start + len(boundary))
+                if start < 0 or next_part < 0:
+                    break
+                part = buffer[start:next_part]
+                buffer = buffer[next_part:]
+                header_end = part.find(b"\r\n\r\n")
+                if header_end < 0:
+                    continue
+                jpeg = part[header_end + 4 :].rstrip(b"\r\n")
+                now = time.monotonic()
+                if previous is not None:
+                    gap = now - previous
+                    self.get_logger().info(f"Image (SDK): {gap:.6f}")
+                    self.stats.record(gap)
+                    self._write_csv(gap, "frame", None)
+                previous = now
+                if jpeg:
+                    self._publish_jpeg(jpeg)
+
+    def destroy_node(self):
+        self._running = False
+        self.get_logger().info(f"[final] {self.stats.summary()}")
+        if self._csv_handle:
+            with self._csv_lock:
+                self._csv_handle.close()
+            self.get_logger().info(f"CSV written to {self.csv_path}")
+        super().destroy_node()
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = ErPollBenchmark()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/ros2/er_poll_benchmark.py
+++ b/examples/ros2/er_poll_benchmark.py
@@ -286,7 +286,9 @@ def main(args=None):
         pass
     finally:
         node.destroy_node()
-        rclpy.shutdown()
+        # SIGINT may have already shut the context down via rclpy's handler.
+        if rclpy.ok():
+            rclpy.shutdown()
 
 
 if __name__ == "__main__":

--- a/examples/ros2/er_poll_benchmark.py
+++ b/examples/ros2/er_poll_benchmark.py
@@ -196,6 +196,10 @@ class ErPollBenchmark(Node):
                             f"No image data in response ({elapsed:.6f}s)"
                         )
                 else:
+                    # A failed HTTP response still consumed a polling tick.
+                    # Include it in latency percentiles so slow failures cannot
+                    # disappear from the benchmark summary.
+                    self.stats.record(elapsed)
                     self.stats.record_error(status)
                     self.get_logger().error(
                         f"No image data in response "
@@ -203,6 +207,7 @@ class ErPollBenchmark(Node):
                     )
             except requests.RequestException as exc:
                 elapsed = time.monotonic() - started
+                self.stats.record(elapsed)
                 self.stats.record_error(type(exc).__name__)
                 self.get_logger().error(f"Request failed ({elapsed:.6f}s): {exc}")
             self._write_csv(elapsed, status, frame_timestamp)
@@ -212,7 +217,11 @@ class ErPollBenchmark(Node):
             if wait > 0:
                 time.sleep(wait)
             else:
-                deadline = time.monotonic()  # fell behind: reset, don't burst
+                # Drop missed ticks. An immediate retry after a slow request can
+                # read that request's still-fresh cached frame and create a
+                # duplicate publication.
+                deadline = time.monotonic() + interval
+                time.sleep(interval)
 
     # ---------------------------------------------------------------- feed
 
@@ -269,7 +278,12 @@ class ErPollBenchmark(Node):
 
     def destroy_node(self):
         self._running = False
-        self.get_logger().info(f"[final] {self.stats.summary()}")
+        summary = f"[final] {self.stats.summary()}"
+        if rclpy.ok():
+            self.get_logger().info(summary)
+        else:
+            # SIGINT can invalidate rosout before destroy_node() runs.
+            print(summary, flush=True)
         if self._csv_handle:
             with self._csv_lock:
                 self._csv_handle.close()

--- a/examples/web/v2_visor.html
+++ b/examples/web/v2_visor.html
@@ -1,0 +1,508 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Earth Rovers /v2 Visor</title>
+    <style>
+      :root {
+        --surface: #0b1220;
+        --panel: #111a2c;
+        --panel-edge: #1e2a42;
+        --ink: #e8edf6;
+        --ink-2: #9fb0c9;
+        --ink-3: #64748b;
+        --accent: #7aa7ff;
+        --good: #34d399;
+        --warn: #fbbf24;
+        --bad: #f87171;
+        --drop: #334155;
+        font-size: 16px;
+      }
+      * { box-sizing: border-box; margin: 0; }
+      body {
+        background: var(--surface);
+        color: var(--ink);
+        font: 400 1rem/1.45 -apple-system, "Segoe UI", Roboto, sans-serif;
+        min-height: 100vh;
+        padding: 20px;
+      }
+      header {
+        display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap;
+        margin-bottom: 14px;
+      }
+      h1 { font-size: 1.15rem; font-weight: 600; letter-spacing: 0.01em; }
+      .sub { color: var(--ink-2); font-size: 0.85rem; }
+      .controls {
+        display: flex; gap: 8px; align-items: center; flex-wrap: wrap;
+        margin-bottom: 16px;
+      }
+      .controls input, .controls select {
+        background: var(--panel); color: var(--ink);
+        border: 1px solid var(--panel-edge); border-radius: 8px;
+        padding: 7px 10px; font-size: 0.85rem;
+      }
+      .controls input#url { width: 230px; }
+      .controls input#rate { width: 64px; }
+      button {
+        background: var(--accent); color: #0a1020; border: 0;
+        border-radius: 8px; padding: 8px 18px; font-size: 0.9rem;
+        font-weight: 600; cursor: pointer;
+      }
+      button.stop { background: var(--bad); }
+      .layout { display: flex; gap: 16px; flex-wrap: wrap; align-items: flex-start; }
+      .video-panel {
+        position: relative; background: var(--panel);
+        border: 1px solid var(--panel-edge); border-radius: 12px;
+        overflow: hidden; flex: 1 1 560px; max-width: 860px;
+      }
+      .video-panel img#frame { display: block; width: 100%; min-height: 320px; }
+      .video-panel .badge {
+        position: absolute; top: 10px; left: 10px;
+        background: rgba(10, 16, 32, 0.75); border-radius: 8px;
+        padding: 4px 10px; font-size: 0.8rem; color: var(--ink-2);
+        display: flex; gap: 8px; align-items: center;
+      }
+      .dot { width: 9px; height: 9px; border-radius: 50%; background: var(--drop); }
+      .dot.live { background: var(--good); }
+      .dot.err { background: var(--bad); }
+      img#rear {
+        position: absolute; right: 10px; bottom: 10px; width: 24%;
+        border: 1px solid var(--panel-edge); border-radius: 8px; display: none;
+      }
+      .side { flex: 1 1 340px; min-width: 320px; display: grid; gap: 12px; }
+      .tiles { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
+      .tile {
+        background: var(--panel); border: 1px solid var(--panel-edge);
+        border-radius: 12px; padding: 10px 12px;
+      }
+      .tile .label {
+        font-size: 0.68rem; letter-spacing: 0.06em; text-transform: uppercase;
+        color: var(--ink-3);
+      }
+      .tile .value {
+        font-size: 1.45rem; font-weight: 650; font-variant-numeric: tabular-nums;
+      }
+      .tile .value small { font-size: 0.8rem; font-weight: 500; color: var(--ink-2); }
+      .tile .value.good { color: var(--good); }
+      .tile .value.bad { color: var(--bad); }
+      .panel {
+        background: var(--panel); border: 1px solid var(--panel-edge);
+        border-radius: 12px; padding: 12px;
+      }
+      .panel h2 {
+        font-size: 0.72rem; letter-spacing: 0.06em; text-transform: uppercase;
+        color: var(--ink-3); font-weight: 600; margin-bottom: 8px;
+        display: flex; justify-content: space-between;
+      }
+      .panel h2 .legend { color: var(--ink-2); text-transform: none; letter-spacing: 0; }
+      .legend b { font-weight: 600; }
+      .legend .sw {
+        display: inline-block; width: 9px; height: 9px; border-radius: 2px;
+        margin: 0 4px 0 10px; vertical-align: baseline;
+      }
+      #ticks { display: flex; flex-wrap: wrap; gap: 3px; }
+      #ticks span {
+        width: 11px; height: 11px; border-radius: 3px; background: var(--drop);
+      }
+      #spark { width: 100%; height: 90px; display: block; cursor: crosshair; }
+      #tip {
+        position: fixed; pointer-events: none; display: none;
+        background: #1a2740; border: 1px solid var(--panel-edge);
+        border-radius: 7px; padding: 5px 9px; font-size: 0.78rem;
+        color: var(--ink); z-index: 10; font-variant-numeric: tabular-nums;
+      }
+      .drive {
+        display: flex; align-items: center; gap: 18px; flex-wrap: wrap;
+        margin-top: 12px;
+      }
+      .pad {
+        display: grid; grid-template-columns: repeat(3, 46px);
+        grid-template-rows: repeat(2, 40px); gap: 5px;
+      }
+      .pad button {
+        background: var(--panel); color: var(--ink);
+        border: 1px solid var(--panel-edge); border-radius: 9px;
+        font-size: 1rem; font-weight: 600; padding: 0; cursor: pointer;
+        user-select: none; -webkit-user-select: none; touch-action: none;
+      }
+      .pad button:active, .pad button.on {
+        background: var(--accent); color: #0a1020; border-color: var(--accent);
+      }
+      .pad #fwd { grid-column: 2; }
+      .pad #left { grid-column: 1; grid-row: 2; }
+      .pad #back { grid-column: 2; grid-row: 2; }
+      .pad #right { grid-column: 3; grid-row: 2; }
+      button#estop {
+        background: var(--bad); color: #0a1020; border-radius: 9px;
+        height: 40px; padding: 0 18px; font-weight: 700;
+      }
+      .drive .speed { display: flex; align-items: center; gap: 8px; }
+      .drive input[type="range"] { width: 120px; accent-color: var(--accent); }
+      .drive .status { font-size: 0.8rem; color: var(--ink-2); font-variant-numeric: tabular-nums; }
+      .drive .keys { font-size: 0.75rem; color: var(--ink-3); }
+      kbd {
+        background: var(--panel); border: 1px solid var(--panel-edge);
+        border-radius: 4px; padding: 1px 5px; font-size: 0.72rem;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Earth Rovers /v2 Visor</h1>
+      <span class="sub">fixed-rate polling probe — every square is one request</span>
+    </header>
+
+    <div class="controls">
+      <input id="url" value="http://localhost:8000" title="SDK base URL" />
+      <select id="endpoint">
+        <option value="/v2/front" selected>/v2/front</option>
+        <option value="/v2/screenshot">/v2/screenshot</option>
+      </select>
+      <input id="rate" type="number" value="10" min="1" max="30" title="Poll rate (Hz)" />
+      <span class="sub">Hz</span>
+      <button id="go">Start</button>
+    </div>
+
+    <div class="layout">
+      <div class="video-panel">
+        <img id="frame" alt="live front camera frame" />
+        <div class="badge"><span class="dot" id="dot"></span><span id="badge-text">idle</span></div>
+        <img id="rear" alt="rear camera frame" />
+      </div>
+
+      <div class="drive" id="drive" style="flex-basis: 100%; order: 3;">
+        <div class="pad">
+          <button id="fwd" title="forward (W / ↑)">▲</button>
+          <button id="left" title="turn left (A / ←)">◀</button>
+          <button id="back" title="backward (S / ↓)">▼</button>
+          <button id="right" title="turn right (D / →)">▶</button>
+        </div>
+        <button id="estop" title="Space">STOP</button>
+        <div class="speed">
+          <span class="sub">speed</span>
+          <input id="speed" type="range" min="0.1" max="1" step="0.1" value="0.5" />
+          <span class="sub" id="speed-val">0.5</span>
+        </div>
+        <div class="status" id="ctrl-status">controls idle</div>
+        <div class="keys">drive with <kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> or arrows — hold to move, release to stop</div>
+      </div>
+
+      <div class="side">
+        <div class="tiles">
+          <div class="tile"><div class="label">Achieved rate</div>
+            <div class="value" id="t-hz">–<small> Hz</small></div></div>
+          <div class="tile"><div class="label">Last request</div>
+            <div class="value" id="t-last">–<small> ms</small></div></div>
+          <div class="tile"><div class="label">Frame age</div>
+            <div class="value" id="t-age">–<small> ms</small></div></div>
+          <div class="tile"><div class="label">p50 / p99</div>
+            <div class="value" id="t-pct">–</div></div>
+          <div class="tile"><div class="label">Max</div>
+            <div class="value" id="t-max">–<small> ms</small></div></div>
+          <div class="tile"><div class="label">Frames</div>
+            <div class="value good" id="t-n">0</div></div>
+          <div class="tile"><div class="label">Errors</div>
+            <div class="value" id="t-err">0</div></div>
+          <div class="tile"><div class="label">Duplicates</div>
+            <div class="value" id="t-dup">0</div></div>
+          <div class="tile"><div class="label">Uptime</div>
+            <div class="value" id="t-up">0<small> s</small></div></div>
+        </div>
+
+        <div class="panel">
+          <h2>Last 120 requests
+            <span class="legend"><span class="sw" style="background:var(--good)"></span>ok
+              <span class="sw" style="background:var(--warn)"></span>&gt;250 ms
+              <span class="sw" style="background:var(--bad)"></span>error</span>
+          </h2>
+          <div id="ticks"></div>
+        </div>
+
+        <div class="panel">
+          <h2>Request latency — last 300 <span class="legend" id="spark-now"></span></h2>
+          <svg id="spark" preserveAspectRatio="none"></svg>
+        </div>
+      </div>
+    </div>
+    <div id="tip"></div>
+
+    <script>
+      const $ = (id) => document.getElementById(id);
+      const SLOW_MS = 250, TICKS = 120, SPARK = 300;
+
+      let running = false;
+      let samples = [], history = [], lastTs = null, startedAt = 0;
+      let frames = 0, errors = 0, dups = 0, recent = [];
+
+      const pct = (arr, f) => {
+        if (!arr.length) return null;
+        const s = [...arr].sort((a, b) => a - b);
+        return s[Math.min(s.length - 1, Math.max(0, Math.round(f * (s.length - 1))))];
+      };
+      const fmt = (v) => (v == null ? "–" : v < 100 ? v.toFixed(1) : Math.round(v));
+
+      function pushTick(kind) {
+        const strip = $("ticks");
+        const cell = document.createElement("span");
+        cell.style.background =
+          kind === "ok" ? "var(--good)" : kind === "slow" ? "var(--warn)" : "var(--bad)";
+        cell.title = kind;
+        strip.appendChild(cell);
+        while (strip.children.length > TICKS) strip.removeChild(strip.firstChild);
+      }
+
+      function renderStats() {
+        const now = performance.now();
+        recent = recent.filter((t) => now - t < 5000);
+        $("t-hz").innerHTML = (recent.length / 5).toFixed(1) + "<small> Hz</small>";
+        $("t-pct").textContent = fmt(pct(samples, 0.5)) + " / " + fmt(pct(samples, 0.99));
+        $("t-max").innerHTML = fmt(pct(samples, 1)) + "<small> ms</small>";
+        $("t-n").textContent = frames;
+        $("t-err").textContent = errors;
+        $("t-err").className = "value" + (errors ? " bad" : "");
+        $("t-dup").textContent = dups;
+        $("t-dup").className = "value" + (dups ? " bad" : "");
+        $("t-up").innerHTML = Math.round((now - startedAt) / 1000) + "<small> s</small>";
+        drawSpark();
+      }
+
+      function drawSpark() {
+        const svg = $("spark");
+        const w = svg.clientWidth, h = svg.clientHeight;
+        svg.setAttribute("viewBox", `0 0 ${w} ${h}`);
+        if (history.length < 2) { svg.innerHTML = ""; return; }
+        const max = Math.max(60, ...history.map((d) => d.ms));
+        const x = (i) => (i / (SPARK - 1)) * (w - 2) + 1;
+        const y = (v) => h - 4 - (v / max) * (h - 12);
+        const start = SPARK - history.length;
+        const line = history
+          .map((d, i) => `${i ? "L" : "M"}${x(start + i).toFixed(1)},${y(d.ms).toFixed(1)}`)
+          .join("");
+        const grid = y(SLOW_MS);
+        svg.innerHTML =
+          (SLOW_MS < max
+            ? `<line x1="0" x2="${w}" y1="${grid}" y2="${grid}" stroke="var(--panel-edge)" stroke-dasharray="3 4"/>
+               <text x="${w - 4}" y="${grid - 4}" fill="var(--ink-3)" font-size="10" text-anchor="end">250 ms</text>`
+            : "") +
+          `<path d="${line}" fill="none" stroke="var(--accent)" stroke-width="2" stroke-linejoin="round"/>` +
+          history.filter((d) => d.err).map((d, _, __) => {
+            const i = history.indexOf(d);
+            return `<circle cx="${x(start + i)}" cy="${y(d.ms)}" r="3.5" fill="var(--bad)" stroke="var(--surface)" stroke-width="2"/>`;
+          }).join("");
+        $("spark-now").textContent = "last " + fmt(history[history.length - 1].ms) + " ms";
+      }
+
+      $("spark").addEventListener("mousemove", (ev) => {
+        if (!history.length) return;
+        const rect = ev.currentTarget.getBoundingClientRect();
+        const frac = (ev.clientX - rect.left) / rect.width;
+        const idx = Math.round(frac * (SPARK - 1)) - (SPARK - history.length);
+        const d = history[Math.max(0, Math.min(history.length - 1, idx))];
+        const tip = $("tip");
+        tip.style.display = "block";
+        tip.style.left = ev.clientX + 12 + "px";
+        tip.style.top = ev.clientY - 10 + "px";
+        tip.textContent = (d.err ? "error — " : "") + d.ms.toFixed(1) + " ms";
+      });
+      $("spark").addEventListener("mouseleave", () => ($("tip").style.display = "none"));
+
+      function record(ms, ok, ts, slow) {
+        if (ok) { samples.push(ms); if (samples.length > 3600) samples.shift(); }
+        history.push({ ms, err: !ok });
+        if (history.length > SPARK) history.shift();
+        pushTick(ok ? (slow ? "slow" : "ok") : "err");
+        $("t-last").innerHTML = fmt(ms) + "<small> ms</small>";
+        $("t-last").className = "value" + (!ok ? " bad" : slow ? "" : " good");
+      }
+
+      async function poll(base, endpoint) {
+        const started = performance.now();
+        try {
+          const res = await fetch(base + endpoint, { cache: "no-store" });
+          if (!running) return; // stopped while this poll was in flight
+          const ms = performance.now() - started;
+          if (!res.ok) {
+            errors++;
+            record(ms, false);
+            $("dot").className = "dot err";
+            $("badge-text").textContent = `HTTP ${res.status} — skipped tick (fail-fast)`;
+            return;
+          }
+          const body = await res.json();
+          const b64 = body.front_frame;
+          if (!b64) { errors++; record(ms, false); return; }
+          if (body.timestamp === lastTs) dups++;
+          lastTs = body.timestamp;
+          frames++;
+          recent.push(performance.now());
+          $("frame").src = "data:image/jpeg;base64," + b64;
+          if (body.rear_frame) {
+            $("rear").style.display = "block";
+            $("rear").src = "data:image/jpeg;base64," + body.rear_frame;
+          }
+          const age = Date.now() / 1000 - body.timestamp;
+          $("t-age").innerHTML = fmt(age * 1000) + "<small> ms</small>";
+          record(ms, true, body.timestamp, ms > SLOW_MS);
+          $("dot").className = "dot live";
+          $("badge-text").textContent = "live — " + new Date(body.timestamp * 1000).toLocaleTimeString();
+        } catch (e) {
+          errors++;
+          record(performance.now() - started, false);
+          $("dot").className = "dot err";
+          $("badge-text").textContent = "unreachable: " + e.message;
+        }
+      }
+
+      // A Web Worker drives the tick: window timers are throttled to 1 Hz in
+      // background/occluded tabs, which would silently drop the poll rate.
+      const ticker = new Worker(
+        URL.createObjectURL(
+          new Blob(
+            ["let t=null;onmessage=(e)=>{clearInterval(t);if(e.data>0)t=setInterval(()=>postMessage(0),e.data);};"],
+            { type: "text/javascript" }
+          )
+        )
+      );
+      let busy = false;
+      ticker.onmessage = async () => {
+        if (!running || busy) return; // a poll still in flight: drop this tick
+        busy = true;
+        try {
+          await poll($("url").value.replace(/\/+$/, ""), $("endpoint").value);
+          renderStats();
+        } finally {
+          busy = false;
+        }
+      };
+
+      function loop() {
+        ticker.postMessage(1000 / Number($("rate").value || 10));
+      }
+
+      // ---- drive controls: latest-wins at 10 Hz, stop on release ----------
+      // Same contract as the ROS bridge: while input is active the newest
+      // command is POSTed to /control at a fixed rate (keeps the SDK's
+      // dead-man watchdog fed); releasing everything sends an explicit stop.
+      const CTRL_HZ = 10;
+      const held = new Set();
+      let stopSent = true, ctrlErrors = 0;
+
+      const ctrlTicker = new Worker(
+        URL.createObjectURL(
+          new Blob(
+            ["let t=null;onmessage=(e)=>{clearInterval(t);if(e.data>0)t=setInterval(()=>postMessage(0),e.data);};"],
+            { type: "text/javascript" }
+          )
+        )
+      );
+      ctrlTicker.postMessage(1000 / CTRL_HZ);
+
+      function currentCommand() {
+        const speed = Number($("speed").value);
+        const linear = ((held.has("fwd") ? 1 : 0) - (held.has("back") ? 1 : 0)) * speed;
+        const angular = ((held.has("left") ? 1 : 0) - (held.has("right") ? 1 : 0)) * speed;
+        return { linear: Number(linear.toFixed(2)), angular: Number(angular.toFixed(2)) };
+      }
+
+      let ctrlBusy = false;
+      async function sendControl(command) {
+        if (ctrlBusy) return;
+        ctrlBusy = true;
+        const started = performance.now();
+        try {
+          const res = await fetch($("url").value.replace(/\/+$/, "") + "/control", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ command }),
+          });
+          const ms = performance.now() - started;
+          if (!res.ok) throw new Error("HTTP " + res.status);
+          // Only a *delivered* zero counts as stopped; a dropped/failed stop
+          // keeps stopSent false so the ticker retries it until it lands.
+          stopSent = !(command.linear || command.angular);
+          $("ctrl-status").textContent =
+            (command.linear || command.angular
+              ? `driving  lin ${command.linear}  ang ${command.angular}`
+              : "stopped") + `  —  /control ${ms.toFixed(0)} ms`;
+        } catch (e) {
+          ctrlErrors++;
+          $("ctrl-status").textContent = `/control failed (${ctrlErrors}): ${e.message}`;
+        } finally {
+          ctrlBusy = false;
+        }
+      }
+
+      ctrlTicker.onmessage = () => {
+        const cmd = currentCommand();
+        if (cmd.linear || cmd.angular) sendControl(cmd);
+        else if (!stopSent) sendControl({ linear: 0, angular: 0 });
+      };
+
+      function setHeld(dir, on) {
+        if (on) held.add(dir); else held.delete(dir);
+        $(dir).classList.toggle("on", on);
+        sendControl(currentCommand());
+      }
+
+      for (const dir of ["fwd", "back", "left", "right"]) {
+        const el = $(dir);
+        el.addEventListener("pointerdown", (e) => { e.preventDefault(); setHeld(dir, true); });
+        for (const ev of ["pointerup", "pointerleave", "pointercancel"])
+          el.addEventListener(ev, () => setHeld(dir, false));
+      }
+      $("estop").addEventListener("click", () => {
+        held.clear();
+        for (const d of ["fwd", "back", "left", "right"]) $(d).classList.remove("on");
+        sendControl({ linear: 0, angular: 0 });
+      });
+      $("speed").addEventListener("input", () => ($("speed-val").textContent = $("speed").value));
+
+      const KEYMAP = {
+        KeyW: "fwd", ArrowUp: "fwd",
+        KeyS: "back", ArrowDown: "back",
+        KeyA: "left", ArrowLeft: "left",
+        KeyD: "right", ArrowRight: "right",
+      };
+      window.addEventListener("keydown", (e) => {
+        if (e.target.tagName === "INPUT" || e.target.tagName === "SELECT") return;
+        if (e.code === "Space") { e.preventDefault(); $("estop").click(); return; }
+        const dir = KEYMAP[e.code];
+        if (!dir || e.repeat) return;
+        e.preventDefault();
+        setHeld(dir, true);
+      });
+      window.addEventListener("keyup", (e) => {
+        const dir = KEYMAP[e.code];
+        if (!dir) return;
+        setHeld(dir, false);
+      });
+      // Never leave the last motion command active if the page goes away.
+      window.addEventListener("pagehide", () => {
+        navigator.sendBeacon(
+          $("url").value.replace(/\/+$/, "") + "/control",
+          new Blob([JSON.stringify({ command: { linear: 0, angular: 0 } })], {
+            type: "application/json",
+          })
+        );
+      });
+
+      $("go").addEventListener("click", () => {
+        running = !running;
+        $("go").textContent = running ? "Stop" : "Start";
+        $("go").className = running ? "stop" : "";
+        if (running) {
+          samples = []; history = []; recent = [];
+          frames = errors = dups = 0; lastTs = null;
+          startedAt = performance.now();
+          $("ticks").innerHTML = "";
+          loop();
+        } else {
+          ticker.postMessage(0);
+          $("dot").className = "dot";
+          $("badge-text").textContent = "stopped";
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/examples/web/v2_visor.html
+++ b/examples/web/v2_visor.html
@@ -140,6 +140,7 @@
       .drive .speed { display: flex; align-items: center; gap: 8px; }
       .drive input[type="range"] { width: 120px; accent-color: var(--accent); }
       .drive .status { font-size: 0.8rem; color: var(--ink-2); font-variant-numeric: tabular-nums; }
+      .srv { font-size: 0.85rem; color: var(--ink-2); font-variant-numeric: tabular-nums; }
       .drive .keys { font-size: 0.75rem; color: var(--ink-3); }
       kbd {
         background: var(--panel); border: 1px solid var(--panel-edge);
@@ -158,8 +159,10 @@
       <select id="endpoint">
         <option value="/v2/front" selected>/v2/front</option>
         <option value="/v2/screenshot">/v2/screenshot</option>
+        <option value="feed">/feed (MJPEG)</option>
       </select>
-      <input id="rate" type="number" value="10" min="1" max="30" title="Poll rate (Hz)" />
+      <input id="rate" type="number" value="10" min="1" max="30"
+             title="Poll rate (Hz) — in /feed mode: requested stream fps" />
       <span class="sub">Hz</span>
       <button id="go">Start</button>
     </div>
@@ -192,7 +195,7 @@
         <div class="tiles">
           <div class="tile"><div class="label">Achieved rate</div>
             <div class="value" id="t-hz">–<small> Hz</small></div></div>
-          <div class="tile"><div class="label">Last request</div>
+          <div class="tile"><div class="label" id="t-last-label">Last request</div>
             <div class="value" id="t-last">–<small> ms</small></div></div>
           <div class="tile"><div class="label">Frame age</div>
             <div class="value" id="t-age">–<small> ms</small></div></div>
@@ -222,6 +225,11 @@
         <div class="panel">
           <h2>Request latency — last 300 <span class="legend" id="spark-now"></span></h2>
           <svg id="spark" preserveAspectRatio="none"></svg>
+        </div>
+
+        <div class="panel">
+          <h2>SDK pipeline (server side) <span class="legend" id="srv-err" style="color:var(--bad)"></span></h2>
+          <div class="srv" id="srv-stats">start polling to sample /status</div>
         </div>
       </div>
     </div>
@@ -367,6 +375,7 @@
       let busy = false;
       ticker.onmessage = async () => {
         if (!running || busy) return; // a poll still in flight: drop this tick
+        if ($("endpoint").value === "feed") return; // stream mode: no polling
         busy = true;
         try {
           await poll($("url").value.replace(/\/+$/, ""), $("endpoint").value);
@@ -376,8 +385,101 @@
         }
       };
 
+      // ---- /feed (MJPEG) mode: consume the multipart stream and measure ---
+      // inter-frame arrival gaps — the same thing OpenCV/ROS sees. Each JPEG
+      // part is rendered, so this is a fair pushed-vs-polled comparison.
+      const CRLF2 = new Uint8Array([13, 10, 13, 10]);
+      const BOUNDARY = new TextEncoder().encode("--frame");
+      let feedAbort = null, feedPrev = null, feedObjUrl = null;
+
+      function indexOfBytes(haystack, needle, from) {
+        outer: for (let i = from; i <= haystack.length - needle.length; i++) {
+          for (let j = 0; j < needle.length; j++)
+            if (haystack[i + j] !== needle[j]) continue outer;
+          return i;
+        }
+        return -1;
+      }
+
+      function onFeedFrame(jpeg) {
+        const now = performance.now();
+        frames++;
+        recent.push(now);
+        if (feedPrev !== null) {
+          const gap = now - feedPrev;
+          record(gap, true, null, gap > SLOW_MS);
+        }
+        feedPrev = now;
+        const url = URL.createObjectURL(new Blob([jpeg], { type: "image/jpeg" }));
+        $("frame").src = url;
+        if (feedObjUrl) URL.revokeObjectURL(feedObjUrl);
+        feedObjUrl = url;
+        $("t-n").textContent = frames;
+        renderStats();
+      }
+
+      async function feedLoop() {
+        const base = $("url").value.replace(/\/+$/, "");
+        const fps = Math.max(1, Math.min(30, Number($("rate").value || 15)));
+        while (running) {
+          feedAbort = new AbortController();
+          feedPrev = null;
+          try {
+            const res = await fetch(`${base}/feed?view=front&fps=${fps}`, {
+              signal: feedAbort.signal, cache: "no-store",
+            });
+            if (!res.ok) throw new Error("HTTP " + res.status);
+            $("dot").className = "dot live";
+            $("badge-text").textContent = `live — MJPEG stream @ ${fps} fps`;
+            const reader = res.body.getReader();
+            let buffer = new Uint8Array(0);
+            while (running) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              const merged = new Uint8Array(buffer.length + value.length);
+              merged.set(buffer); merged.set(value, buffer.length);
+              buffer = merged;
+              while (true) {
+                const start = indexOfBytes(buffer, BOUNDARY, 0);
+                if (start < 0) break;
+                const next = indexOfBytes(buffer, BOUNDARY, start + BOUNDARY.length);
+                if (next < 0) {
+                  if (start > 0) buffer = buffer.slice(start);
+                  break;
+                }
+                const part = buffer.slice(start, next);
+                buffer = buffer.slice(next);
+                const headerEnd = indexOfBytes(part, CRLF2, 0);
+                if (headerEnd < 0) continue;
+                let jpeg = part.slice(headerEnd + 4);
+                let end = jpeg.length;
+                while (end && (jpeg[end - 1] === 13 || jpeg[end - 1] === 10)) end--;
+                if (end > 0) onFeedFrame(jpeg.slice(0, end));
+              }
+            }
+            if (running) throw new Error("stream ended");
+          } catch (e) {
+            if (!running) break;
+            errors++;
+            pushTick("err");
+            $("t-err").textContent = errors;
+            $("t-err").className = "value bad";
+            $("dot").className = "dot err";
+            $("badge-text").textContent = "feed reconnecting: " + e.message;
+            await new Promise((r) => setTimeout(r, 2000));
+          }
+        }
+      }
+
       function loop() {
-        ticker.postMessage(1000 / Number($("rate").value || 10));
+        if ($("endpoint").value === "feed") {
+          $("t-last-label").textContent = "Frame gap";
+          $("t-age").innerHTML = "–";
+          feedLoop();
+        } else {
+          $("t-last-label").textContent = "Last request";
+          ticker.postMessage(1000 / Number($("rate").value || 10));
+        }
       }
 
       // ---- drive controls: latest-wins at 10 Hz, stop on release ----------
@@ -487,18 +589,56 @@
         );
       });
 
+      // ---- server-side pipeline health via /status ------------------------
+      // Distinguishes where a stall lives: capture fps collapsing = the SDK's
+      // page can't produce frames (host/renderer/stream); capture fps fine
+      // while client latency spikes = HTTP/consumer side.
+      let statusTimer = null, lastStatusSample = null;
+      async function pollStatus() {
+        try {
+          const res = await fetch($("url").value.replace(/\/+$/, "") + "/status");
+          const s = await res.json();
+          if (!s.video) {
+            $("srv-stats").textContent =
+              "this SDK has no video stats — running a build older than v6.2";
+            return;
+          }
+          const v = s.video.front || {};
+          const now = performance.now();
+          let fps = "–";
+          if (lastStatusSample && v.captures_total != null) {
+            const delta = v.captures_total - lastStatusSample.captures;
+            fps = Math.max(0, delta / ((now - lastStatusSample.at) / 1000)).toFixed(1);
+          }
+          lastStatusSample = { captures: v.captures_total, at: now };
+          const age = v.latest_frame_age_s;
+          $("srv-stats").textContent =
+            `capture ${fps} fps · server frame age ` +
+            (age == null ? "–" : `${(age * 1000).toFixed(0)} ms`) +
+            ` · capture failures ${v.failures_total ?? "–"}` +
+            ` · loop ${v.loop_running ? "running" : "stopped"}`;
+          $("srv-err").textContent = v.last_error || "";
+        } catch (e) {
+          $("srv-stats").textContent = "status unavailable: " + e.message;
+        }
+      }
+
       $("go").addEventListener("click", () => {
         running = !running;
         $("go").textContent = running ? "Stop" : "Start";
         $("go").className = running ? "stop" : "";
         if (running) {
           samples = []; history = []; recent = [];
-          frames = errors = dups = 0; lastTs = null;
+          frames = errors = dups = 0; lastTs = null; lastStatusSample = null;
           startedAt = performance.now();
           $("ticks").innerHTML = "";
           loop();
+          pollStatus();
+          statusTimer = setInterval(pollStatus, 3000);
         } else {
           ticker.postMessage(0);
+          feedAbort?.abort();
+          clearInterval(statusTimer);
           $("dot").className = "dot";
           $("badge-text").textContent = "stopped";
         }

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ from browser_service import FEED_QUALITY, FORMAT, QUALITY, BrowserService
 from rtm_client import RtmClient
 from telemetry_hub import TelemetryHub
 from tts_service import generate_speech
-from video_feed import FrameBroadcaster
+from video_feed import FrameBroadcaster, FrameCaptureError
 
 load_dotenv()
 
@@ -133,9 +133,12 @@ async def get_camera_frame(
     """Return a shared fresh frame and its capture timestamp."""
     if FORMAT == "jpeg" and QUALITY == FEED_QUALITY:
         broadcaster = feed_broadcasters[view]
-        frame = await broadcaster.get_frame(
-            max_age=1 / 30, timeout=V2_FRAME_TIMEOUT_S, fps=30
-        )
+        try:
+            frame = await broadcaster.get_frame(
+                max_age=1 / 30, timeout=V2_FRAME_TIMEOUT_S, fps=30
+            )
+        except FrameCaptureError as exc:
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
         if frame:
             return frame.base64_data, frame.captured_at
         if broadcaster.last_error:
@@ -144,7 +147,14 @@ async def get_camera_frame(
 
     # Preserve explicit png/webp v2 configurations. The default and fastest
     # path is JPEG and shares the feed broadcaster above.
-    packet = await browser_service.configured_frame(view)
+    try:
+        packet = await asyncio.wait_for(
+            browser_service.configured_frame(view), timeout=V2_FRAME_TIMEOUT_S
+        )
+    except asyncio.TimeoutError as exc:
+        raise HTTPException(
+            status_code=503, detail=f"{view} camera capture timed out"
+        ) from exc
     if packet and packet.get("error"):
         raise HTTPException(status_code=503, detail=packet["error"])
     if not packet or not packet.get("data_url"):

--- a/main.py
+++ b/main.py
@@ -75,6 +75,12 @@ FRODOBOTS_API_URL = os.getenv(
     "FRODOBOTS_API_URL", "https://frodobots-web-api.onrender.com/api/v1"
 )
 
+# How long /v2/* waits for a fresh frame before failing. Kept short on
+# purpose: with the warm capture loop a healthy camera answers in tens of
+# milliseconds, so this budget only matters as "wait for recovery" during a
+# transient capture blip — better a fast 404/503 than a multi-second stall.
+V2_FRAME_TIMEOUT_S = float(os.getenv("V2_FRAME_TIMEOUT_S", "2"))
+
 
 # In-memory storage for the response
 auth_response_data = {}
@@ -127,7 +133,9 @@ async def get_camera_frame(
     """Return a shared fresh frame and its capture timestamp."""
     if FORMAT == "jpeg" and QUALITY == FEED_QUALITY:
         broadcaster = feed_broadcasters[view]
-        frame = await broadcaster.get_frame(max_age=1 / 30, timeout=5, fps=30)
+        frame = await broadcaster.get_frame(
+            max_age=1 / 30, timeout=V2_FRAME_TIMEOUT_S, fps=30
+        )
         if frame:
             return frame.base64_data, frame.captured_at
         if broadcaster.last_error:
@@ -252,6 +260,16 @@ async def ws_data(websocket: WebSocket):
 
 @app.get("/status")
 async def get_status():
+    video = {
+        view: {
+            "loop_running": broadcaster.loop_running,
+            "latest_frame_age_s": broadcaster.latest_age_seconds,
+            "captures_total": broadcaster.captures_total,
+            "failures_total": broadcaster.failures_total,
+            "last_error": broadcaster.last_error,
+        }
+        for view, broadcaster in feed_broadcasters.items()
+    }
     return JSONResponse(
         content={
             "browser_ready": browser_service.is_ready,
@@ -259,6 +277,7 @@ async def get_status():
             "mission_started": bool(auth_response_data)
             or not os.getenv("MISSION_SLUG"),
             "rtm": await browser_service.rtm_health(),
+            "video": video,
             **telemetry_hub.status(),
         }
     )

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -70,6 +70,49 @@ class BrowserRecoveryTest(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(service.is_ready)
 
 
+class RearCameraCacheTest(unittest.IsolatedAsyncioTestCase):
+    # /v2/screenshot consults has_rear_camera() on every poll; the answer
+    # must come from cache, not a page.evaluate round trip per request.
+
+    def _service(self, result):
+        service = BrowserService()
+        service._page = FakePage()
+        service._browser = FakeBrowser()
+        service._ready = True
+        service.run_calls = 0
+
+        async def run(fn, **kwargs):
+            service.run_calls += 1
+            return result
+
+        service._run = run
+        return service
+
+    async def test_positive_result_is_cached_until_teardown(self):
+        service = self._service(True)
+        self.assertTrue(await service.has_rear_camera())
+        self.assertTrue(await service.has_rear_camera())
+        self.assertEqual(service.run_calls, 1)
+
+        await service._teardown()  # relaunch must re-detect capability
+        self.assertTrue(await service.has_rear_camera())
+        self.assertEqual(service.run_calls, 2)
+
+    async def test_negative_result_expires_quickly(self):
+        import time
+
+        service = self._service(False)
+        self.assertFalse(await service.has_rear_camera())
+        self.assertFalse(await service.has_rear_camera())
+        self.assertEqual(service.run_calls, 1)
+
+        # The rear track can subscribe late after the Agora join, so a
+        # negative answer only holds for a short TTL.
+        service._rear_camera = (False, time.monotonic() - 1)
+        self.assertFalse(await service.has_rear_camera())
+        self.assertEqual(service.run_calls, 2)
+
+
 class LockLoopBindingTest(unittest.IsolatedAsyncioTestCase):
     async def test_lock_is_rebound_when_the_event_loop_changes(self):
         # The service is constructed at import time, before hypercorn's loop

--- a/tests/test_screenshot_endpoint.py
+++ b/tests/test_screenshot_endpoint.py
@@ -34,5 +34,43 @@ class ScreenshotPersistenceTest(unittest.IsolatedAsyncioTestCase):
                 main.auth_response_data = {}
 
 
+class StubBroadcaster:
+    def __init__(self, last_error=None):
+        self.last_error = last_error
+        self.get_frame_kwargs = None
+
+    async def get_frame(self, **kwargs):
+        self.get_frame_kwargs = kwargs
+        return None
+
+
+class CameraFrameFailFastTest(unittest.IsolatedAsyncioTestCase):
+    async def test_v2_uses_short_timeout_and_surfaces_capture_error(self):
+        stub = StubBroadcaster(last_error="camera frame is not available")
+        with patch.dict(main.feed_broadcasters, {"front": stub}):
+            with self.assertRaises(main.HTTPException) as ctx:
+                await main.get_camera_frame("front")
+
+        self.assertEqual(ctx.exception.status_code, 503)
+        self.assertEqual(ctx.exception.detail, "camera frame is not available")
+        # Fail fast: a poll is bounded by the short v2 budget, not the old 5s.
+        self.assertEqual(
+            stub.get_frame_kwargs["timeout"], main.V2_FRAME_TIMEOUT_S
+        )
+
+    async def test_front_endpoint_404s_when_frame_missing_without_error(self):
+        main.auth_response_data = {"BOT_UID": "bot"}
+        try:
+            with (
+                patch.dict(os.environ, {"MISSION_SLUG": ""}),
+                patch.dict(main.feed_broadcasters, {"front": StubBroadcaster()}),
+            ):
+                with self.assertRaises(main.HTTPException) as ctx:
+                    await main.get_front_frame()
+            self.assertEqual(ctx.exception.status_code, 404)
+        finally:
+            main.auth_response_data = {}
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_screenshot_endpoint.py
+++ b/tests/test_screenshot_endpoint.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import tempfile
@@ -5,6 +6,7 @@ import unittest
 from unittest.mock import AsyncMock, patch
 
 import main
+from video_feed import FrameCaptureError
 
 
 class ScreenshotPersistenceTest(unittest.IsolatedAsyncioTestCase):
@@ -44,6 +46,12 @@ class StubBroadcaster:
         return None
 
 
+class FailingBroadcaster(StubBroadcaster):
+    async def get_frame(self, **kwargs):
+        self.get_frame_kwargs = kwargs
+        raise FrameCaptureError("renderer unavailable")
+
+
 class CameraFrameFailFastTest(unittest.IsolatedAsyncioTestCase):
     async def test_v2_uses_short_timeout_and_surfaces_capture_error(self):
         stub = StubBroadcaster(last_error="camera frame is not available")
@@ -70,6 +78,30 @@ class CameraFrameFailFastTest(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(ctx.exception.status_code, 404)
         finally:
             main.auth_response_data = {}
+
+    async def test_capture_failure_is_immediate_503(self):
+        stub = FailingBroadcaster()
+        with patch.dict(main.feed_broadcasters, {"front": stub}):
+            with self.assertRaises(main.HTTPException) as ctx:
+                await main.get_camera_frame("front")
+
+        self.assertEqual(ctx.exception.status_code, 503)
+        self.assertEqual(ctx.exception.detail, "renderer unavailable")
+
+    async def test_nondefault_capture_path_is_bounded(self):
+        async def capture(_view):
+            await asyncio.sleep(1)
+
+        with (
+            patch.object(main, "FORMAT", "png"),
+            patch.object(main, "V2_FRAME_TIMEOUT_S", 0.05),
+            patch.object(main.browser_service, "configured_frame", capture),
+        ):
+            with self.assertRaises(main.HTTPException) as ctx:
+                await main.get_camera_frame("front")
+
+        self.assertEqual(ctx.exception.status_code, 503)
+        self.assertEqual(ctx.exception.detail, "front camera capture timed out")
 
 
 if __name__ == "__main__":

--- a/tests/test_video_feed.py
+++ b/tests/test_video_feed.py
@@ -5,7 +5,7 @@ import unittest
 from unittest.mock import patch
 
 import video_feed
-from video_feed import FrameBroadcaster
+from video_feed import FrameBroadcaster, FrameCaptureError
 
 
 JPEG_DATA_URL = "data:image/jpeg;base64," + base64.b64encode(
@@ -157,7 +157,7 @@ class FrameBroadcasterTest(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(broadcaster.loop_running)
         self.assertIsNone(broadcaster._task)
 
-    async def test_failing_capture_fails_fast_not_after_backoff(self):
+    async def test_failing_capture_notifies_snapshot_before_backoff(self):
         # The recovery backoff belongs to the background loop. A request is
         # bounded by its own timeout — never by backoff sleeps (which used
         # to stretch a poll to 2-5 s before returning empty).
@@ -167,15 +167,52 @@ class FrameBroadcasterTest(unittest.IsolatedAsyncioTestCase):
         broadcaster = FrameBroadcaster(capture)
         try:
             started = time.monotonic()
-            frame = await broadcaster.get_frame(max_age=1 / 30, timeout=0.5)
+            with self.assertRaises(FrameCaptureError) as ctx:
+                await broadcaster.get_frame(max_age=1 / 30, timeout=0.5)
             elapsed = time.monotonic() - started
-            self.assertIsNone(frame)
-            self.assertLess(elapsed, 1.0)
+            self.assertLess(elapsed, 0.2)
             self.assertGreaterEqual(broadcaster.failures_total, 1)
+            self.assertEqual(str(ctx.exception), "camera frame is not available")
             self.assertEqual(
                 broadcaster.last_error, "camera frame is not available"
             )
         finally:
+            await broadcaster.close()
+
+    async def test_snapshot_during_recovery_does_not_join_backoff(self):
+        async def capture():
+            return None
+
+        broadcaster = FrameBroadcaster(capture)
+        try:
+            with self.assertRaises(FrameCaptureError):
+                await broadcaster.get_frame(max_age=1 / 30, timeout=1)
+
+            started = time.monotonic()
+            with self.assertRaises(FrameCaptureError):
+                await broadcaster.get_frame(max_age=1 / 30, timeout=1)
+            self.assertLess(time.monotonic() - started, 0.05)
+        finally:
+            await broadcaster.close()
+
+    async def test_feed_client_stays_subscribed_across_capture_failure(self):
+        calls = 0
+
+        async def capture():
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return None
+            return {"data_url": JPEG_DATA_URL, "timestamp": time.time()}
+
+        broadcaster = FrameBroadcaster(capture)
+        queue = await broadcaster.subscribe(30, cached_max_age=0)
+        try:
+            frame = await asyncio.wait_for(queue.get(), timeout=1)
+            self.assertEqual(frame.jpeg, b"\xff\xd8test-frame\xff\xd9")
+            self.assertEqual(broadcaster.failures_total, 1)
+        finally:
+            await broadcaster.unsubscribe(queue)
             await broadcaster.close()
 
     async def test_close_during_linger_stops_loop_promptly(self):

--- a/tests/test_video_feed.py
+++ b/tests/test_video_feed.py
@@ -2,7 +2,9 @@ import asyncio
 import base64
 import time
 import unittest
+from unittest.mock import patch
 
+import video_feed
 from video_feed import FrameBroadcaster
 
 
@@ -30,6 +32,7 @@ class FrameBroadcasterTest(unittest.IsolatedAsyncioTestCase):
         finally:
             await broadcaster.unsubscribe(first)
             await broadcaster.unsubscribe(second)
+            await broadcaster.close()
 
     async def test_snapshot_reuses_fresh_cached_frame(self):
         calls = 0
@@ -40,8 +43,11 @@ class FrameBroadcasterTest(unittest.IsolatedAsyncioTestCase):
             return {"data_url": JPEG_DATA_URL, "timestamp": time.time()}
 
         broadcaster = FrameBroadcaster(capture)
-        first = await broadcaster.get_frame(max_age=1, timeout=1)
-        second = await broadcaster.get_frame(max_age=1, timeout=1)
+        # Linger disabled: this test pins the cache contract when the loop
+        # is cold — a fresh cached frame is served without a new capture.
+        with patch.object(video_feed, "IDLE_LINGER_S", 0):
+            first = await broadcaster.get_frame(max_age=1, timeout=1)
+            second = await broadcaster.get_frame(max_age=1, timeout=1)
         self.assertIs(first, second)
         self.assertEqual(calls, 1)
 
@@ -60,6 +66,7 @@ class FrameBroadcasterTest(unittest.IsolatedAsyncioTestCase):
             self.assertLessEqual(calls, 2)
         finally:
             await broadcaster.unsubscribe(queue)
+            await broadcaster.close()
 
     async def test_close_wakes_waiting_clients_with_sentinel(self):
         # A camera that never produces a frame keeps stream clients blocked
@@ -94,6 +101,7 @@ class FrameBroadcasterTest(unittest.IsolatedAsyncioTestCase):
         self.assertIs(broadcaster._get_lock(), lock)
         queue = await broadcaster.subscribe(10, cached_max_age=0)
         await broadcaster.unsubscribe(queue)
+        await broadcaster.close()
 
     async def test_close_replaces_stale_frame_with_sentinel(self):
         # A slow client with an undelivered frame still gets the sentinel.
@@ -105,6 +113,82 @@ class FrameBroadcasterTest(unittest.IsolatedAsyncioTestCase):
         queue.put_nowait(object())  # simulate an unconsumed frame
         await broadcaster.close()
         self.assertIsNone(queue.get_nowait())
+
+    async def test_polling_keeps_capture_loop_warm_between_requests(self):
+        # A 10 Hz snapshot poller must hit a warm cache, not pay loop
+        # startup (or a failure backoff) inside every request.
+        calls = 0
+
+        async def capture():
+            nonlocal calls
+            calls += 1
+            return {"data_url": JPEG_DATA_URL, "timestamp": time.time()}
+
+        broadcaster = FrameBroadcaster(capture)
+        try:
+            first = await broadcaster.get_frame(max_age=1 / 30, timeout=1)
+            self.assertIsNotNone(first)
+            self.assertTrue(broadcaster.loop_running)
+            task = broadcaster._task
+
+            await asyncio.sleep(0.15)  # several capture intervals, no clients
+            self.assertTrue(broadcaster.loop_running)
+            self.assertIs(broadcaster._task, task)
+            self.assertGreater(calls, 1)  # kept capturing with no subscribers
+
+            started = time.monotonic()
+            second = await broadcaster.get_frame(max_age=1 / 30, timeout=1)
+            self.assertLess(time.monotonic() - started, 0.2)
+            self.assertIsNotNone(second)
+            self.assertIsNot(first, second)  # a fresh frame, not the old one
+            self.assertGreater(broadcaster.captures_total, 1)
+        finally:
+            await broadcaster.close()
+
+    async def test_capture_loop_exits_after_idle_linger(self):
+        async def capture():
+            return {"data_url": JPEG_DATA_URL, "timestamp": time.time()}
+
+        broadcaster = FrameBroadcaster(capture)
+        with patch.object(video_feed, "IDLE_LINGER_S", 0.05):
+            await broadcaster.get_frame(max_age=0, timeout=1)
+            self.assertTrue(broadcaster.loop_running)
+            await asyncio.sleep(0.3)
+        self.assertFalse(broadcaster.loop_running)
+        self.assertIsNone(broadcaster._task)
+
+    async def test_failing_capture_fails_fast_not_after_backoff(self):
+        # The recovery backoff belongs to the background loop. A request is
+        # bounded by its own timeout — never by backoff sleeps (which used
+        # to stretch a poll to 2-5 s before returning empty).
+        async def capture():
+            return None
+
+        broadcaster = FrameBroadcaster(capture)
+        try:
+            started = time.monotonic()
+            frame = await broadcaster.get_frame(max_age=1 / 30, timeout=0.5)
+            elapsed = time.monotonic() - started
+            self.assertIsNone(frame)
+            self.assertLess(elapsed, 1.0)
+            self.assertGreaterEqual(broadcaster.failures_total, 1)
+            self.assertEqual(
+                broadcaster.last_error, "camera frame is not available"
+            )
+        finally:
+            await broadcaster.close()
+
+    async def test_close_during_linger_stops_loop_promptly(self):
+        # Mission teardown must not wait out the idle linger.
+        async def capture():
+            return {"data_url": JPEG_DATA_URL, "timestamp": time.time()}
+
+        broadcaster = FrameBroadcaster(capture)
+        await broadcaster.get_frame(max_age=0, timeout=1)
+        self.assertTrue(broadcaster.loop_running)
+        await broadcaster.close()
+        self.assertFalse(broadcaster.loop_running)
+        self.assertIsNone(broadcaster._task)
 
 
 if __name__ == "__main__":

--- a/video_feed.py
+++ b/video_feed.py
@@ -3,6 +3,7 @@ import base64
 import binascii
 import contextlib
 import logging
+import os
 import time
 from dataclasses import dataclass
 from typing import Awaitable, Callable, Optional, Union
@@ -13,6 +14,13 @@ import numpy as np
 logger = logging.getLogger("video_feed")
 
 JPEG_QUALITY = 85
+
+# How long the capture loop keeps running after the last subscriber leaves.
+# Snapshot pollers (ROS querying /v2/* at 10 Hz) subscribe for a single frame
+# at a time; without a linger every poll would pay loop startup — and any
+# transient capture failure would run its recovery backoff inside the
+# request — instead of hitting a warm latest-frame cache.
+IDLE_LINGER_S = float(os.getenv("FEED_IDLE_LINGER_S", "10"))
 
 
 @dataclass(frozen=True)
@@ -62,7 +70,11 @@ class FrameBroadcaster:
         self._lock_loop = None
         self._task: Optional[asyncio.Task] = None
         self._latest: Optional[Frame] = None
+        self._demand_until = 0.0
+        self._linger_fps = 0
         self.last_error: Optional[str] = None
+        self.captures_total = 0
+        self.failures_total = 0
 
     def _get_lock(self) -> asyncio.Lock:
         # Broadcasters are constructed at import time, before the serving
@@ -84,11 +96,27 @@ class FrameBroadcaster:
             return frame
         return None
 
+    @property
+    def loop_running(self) -> bool:
+        return bool(self._task and not self._task.done())
+
+    @property
+    def latest_age_seconds(self) -> Optional[float]:
+        frame = self._latest
+        if frame is None:
+            return None
+        return time.monotonic() - frame.captured_monotonic
+
+    def _note_demand(self, fps: int):
+        self._demand_until = time.monotonic() + IDLE_LINGER_S
+        self._linger_fps = max(self._linger_fps, fps)
+
     async def subscribe(
         self, fps: int, *, cached_max_age: float = 1.0
     ) -> asyncio.Queue:
         queue: asyncio.Queue = asyncio.Queue(maxsize=1)
         async with self._get_lock():
+            self._note_demand(fps)
             self._clients[queue] = fps
             cached = self.latest_if_fresh(max_age=cached_max_age)
             if cached:
@@ -101,7 +129,13 @@ class FrameBroadcaster:
         task = None
         async with self._get_lock():
             self._clients.pop(queue, None)
-            if not self._clients and self._task:
+            # Within the linger window the loop stays warm for the next
+            # subscriber or poller; it shuts itself down once demand expires.
+            if (
+                not self._clients
+                and self._task
+                and time.monotonic() >= self._demand_until
+            ):
                 task = self._task
                 self._task = None
                 task.cancel()
@@ -112,6 +146,7 @@ class FrameBroadcaster:
     async def get_frame(
         self, *, max_age: float = 0.1, timeout: float = 5.0, fps: int = 30
     ) -> Optional[Frame]:
+        self._note_demand(fps)
         cached = self.latest_if_fresh(max_age)
         if cached:
             return cached
@@ -129,6 +164,8 @@ class FrameBroadcaster:
             clients = list(self._clients)
             self._clients.clear()
             self._latest = None
+            self._demand_until = 0.0
+            self._linger_fps = 0
             if self._task:
                 task = self._task
                 self._task = None
@@ -146,7 +183,11 @@ class FrameBroadcaster:
                 await task
 
     def _capture_fps(self) -> int:
-        return max(self._clients.values(), default=1)
+        # A snapshot poller subscribes only for one frame at a time, so its
+        # rate lives in _linger_fps rather than _clients: keep capturing at
+        # the demanded cadence for the whole linger window.
+        linger = self._linger_fps if time.monotonic() < self._demand_until else 0
+        return max(max(self._clients.values(), default=1), linger)
 
     async def _build_frame(self, result: CaptureResult) -> Optional[Frame]:
         if isinstance(result, dict):
@@ -175,6 +216,15 @@ class FrameBroadcaster:
     async def _capture_loop(self):
         failures = 0
         while True:
+            async with self._get_lock():
+                # Self-shutdown once nothing has wanted frames for a while.
+                # Done under the same lock subscribe() uses to restart the
+                # task, so a subscriber can never race a dying loop.
+                if not self._clients and time.monotonic() >= self._demand_until:
+                    if self._task is asyncio.current_task():
+                        self._task = None
+                        self._linger_fps = 0
+                    return
             started = time.monotonic()
             try:
                 frame = await self._build_frame(await self._capture_fn())
@@ -182,6 +232,7 @@ class FrameBroadcaster:
                     raise RuntimeError("camera frame is not available")
                 failures = 0
                 self.last_error = None
+                self.captures_total += 1
                 self._latest = frame
                 for queue in list(self._clients):
                     if queue.full():
@@ -193,6 +244,7 @@ class FrameBroadcaster:
                 raise
             except Exception as exc:
                 failures += 1
+                self.failures_total += 1
                 self.last_error = str(exc).split("\n", 1)[0]
                 if failures in (1, 5) or failures % 30 == 0:
                     logger.warning("Feed capture failing (%s): %s", failures, exc)

--- a/video_feed.py
+++ b/video_feed.py
@@ -37,6 +37,15 @@ class Frame:
         return self.data_url.split(",", 1)[1]
 
 
+class FrameCaptureError(RuntimeError):
+    """A snapshot capture failed while its caller was waiting."""
+
+
+@dataclass(frozen=True)
+class _CaptureFailure:
+    message: str
+
+
 CaptureResult = Union[str, dict, None]
 
 
@@ -66,6 +75,7 @@ class FrameBroadcaster:
     def __init__(self, capture_fn: Callable[[], Awaitable[CaptureResult]]):
         self._capture_fn = capture_fn
         self._clients: dict[asyncio.Queue, int] = {}
+        self._failure_waiters: set[asyncio.Queue] = set()
         self._lock: Optional[asyncio.Lock] = None
         self._lock_loop = None
         self._task: Optional[asyncio.Task] = None
@@ -112,12 +122,18 @@ class FrameBroadcaster:
         self._linger_fps = max(self._linger_fps, fps)
 
     async def subscribe(
-        self, fps: int, *, cached_max_age: float = 1.0
+        self,
+        fps: int,
+        *,
+        cached_max_age: float = 1.0,
+        notify_capture_failure: bool = False,
     ) -> asyncio.Queue:
         queue: asyncio.Queue = asyncio.Queue(maxsize=1)
         async with self._get_lock():
             self._note_demand(fps)
             self._clients[queue] = fps
+            if notify_capture_failure:
+                self._failure_waiters.add(queue)
             cached = self.latest_if_fresh(max_age=cached_max_age)
             if cached:
                 queue.put_nowait(cached)
@@ -129,6 +145,7 @@ class FrameBroadcaster:
         task = None
         async with self._get_lock():
             self._clients.pop(queue, None)
+            self._failure_waiters.discard(queue)
             # Within the linger window the loop stays warm for the next
             # subscriber or poller; it shuts itself down once demand expires.
             if (
@@ -150,9 +167,20 @@ class FrameBroadcaster:
         cached = self.latest_if_fresh(max_age)
         if cached:
             return cached
-        queue = await self.subscribe(fps, cached_max_age=max_age)
+        # A running loop with an error is sleeping/retrying in the background.
+        # Snapshot callers should skip this tick instead of waiting inside that
+        # backoff. If the loop is cold, subscribe below so a new capture attempt
+        # can start even when last_error came from an earlier loop generation.
+        if self.loop_running and self.last_error:
+            raise FrameCaptureError(self.last_error)
+        queue = await self.subscribe(
+            fps, cached_max_age=max_age, notify_capture_failure=True
+        )
         try:
-            return await asyncio.wait_for(queue.get(), timeout=timeout)
+            result = await asyncio.wait_for(queue.get(), timeout=timeout)
+            if isinstance(result, _CaptureFailure):
+                raise FrameCaptureError(result.message)
+            return result
         except asyncio.TimeoutError:
             return None
         finally:
@@ -163,6 +191,7 @@ class FrameBroadcaster:
         async with self._get_lock():
             clients = list(self._clients)
             self._clients.clear()
+            self._failure_waiters.clear()
             self._latest = None
             self._demand_until = 0.0
             self._linger_fps = 0
@@ -246,6 +275,13 @@ class FrameBroadcaster:
                 failures += 1
                 self.failures_total += 1
                 self.last_error = str(exc).split("\n", 1)[0]
+                # Snapshot callers should skip this tick immediately. Keep
+                # streaming clients subscribed while the loop performs its
+                # recovery backoff in the background.
+                failure = _CaptureFailure(self.last_error)
+                for queue in list(self._failure_waiters):
+                    with contextlib.suppress(asyncio.QueueFull):
+                        queue.put_nowait(failure)
                 if failures in (1, 5) or failures % 30 == 0:
                     logger.warning("Feed capture failing (%s): %s", failures, exc)
 


### PR DESCRIPTION
## Problem

Researchers polling `GET /v2/screenshot` / `/v2/front` at 10 Hz from ROS (NUS report) saw mostly ~60 ms responses interrupted by periodic 2–5 s stalls and "no image data" errors, while the dashboard stayed smooth.

Root cause: at 10 Hz the 33 ms frame cache never hits, so **every poll spawned a capture loop, awaited one frame, and cancelled the loop**. Worse, a transient capture failure ran its exponential recovery backoff **while requests waited on it** — surfacing as the observed 2–5 s spikes followed by a 404. (`/feed` was unaffected because a streaming connection keeps the capture loop alive; the dashboard joins the WebRTC stream independently.)

## Fix

- **Idle-linger capture loop** (`FEED_IDLE_LINGER_S`, default 10 s): snapshot demand keeps the shared capture loop warm between polls. Steady pollers hit the latest-frame cache; the loop shuts itself down after demand expires; mission-end teardown is immediate.
- **Fail fast, strict fresh**: `/v2/*` never serves stale frames. A capture failure is surfaced to snapshot callers **the moment it happens** — an immediate 503 carrying the real error (`FrameCaptureError`) — while recovery backoff continues in the background and `/feed` clients stay subscribed through it. Polls arriving mid-recovery skip instantly instead of joining the 250/500/1000/2000 ms backoff sleeps. Every path (including non-default `IMAGE_FORMAT`/`IMAGE_QUALITY` captures) is bounded by `V2_FRAME_TIMEOUT_S` (default 2 s, was 5 s).
- **`has_rear_camera()` cached** (positive until page teardown, negative 5 s): `/v2/screenshot` no longer pays a `page.evaluate` round trip per poll.
- **`/status` → `video` section**: per-camera `loop_running`, `latest_frame_age_s`, `captures_total`, `failures_total`, `last_error` for correlating client-side spikes with server-side capture health.
- **New benchmarks**: `examples/benchmarks/latency_probe.py` (plain Python) and `examples/ros2/er_poll_benchmark.py` (rclpy node replicating the researcher's polling pattern; publishes `sensor_msgs/CompressedImage`, no cv_bridge needed) + `examples/ros2/Dockerfile` (ros:humble for macOS/Windows hosts). Failed requests count toward latency percentiles; missed ticks are dropped instead of bursting.

## Live before/after (bot `r2d2-flap-seal`, same conditions, 6 min @ 10 Hz)

| `/v2/front` @ 10 Hz | main | this PR |
|---|---|---|
| p50 / p90 / p99 | 23.9 / 27.2 / 41.8 ms | **3.8 / 4.9 / 18.0 ms** |
| max | **3,125 ms** | **83 ms** |
| samples > 1 s | 2 | 0 |
| duplicate frames | 7 | 0 |
| samples completed | 3,528 | 3,600 (full 10 Hz) |

`/feed` unchanged (p99 ≈ 91 ms @ 15 fps in both runs). ROS 2 confirmation (rclpy inside Docker `ros:humble`, 150 s @ 10 Hz): p50 5.7 ms, p99 22.7 ms, max 57 ms, zero errors, zero duplicates.

## Failure-path hardening (from review)

Review caught that the warm-cache fix alone still let polls arriving during backoff wait inside it, bounded at ~2 s. Fault injection (4 consecutive capture failures under a 10 Hz poll, 60 requests):

| | warm cache only | + immediate failure notification |
|---|---|---|
| p99 / max | 1,695 / **2,001 ms** | 0.1 / **0.4 ms** |
| samples > 0.5 s | 2 | 0 |

ROS 2 fault-injection through Docker confirms: zero requests over 0.5 s, zero duplicates, automatic recovery of image publication.

## Tests

41/41 passing. Coverage includes: loop stays warm between polls; loop self-exits after linger; capture failure raises immediately (not after backoff); polls during recovery don't join backoff; `/feed` clients stay subscribed across capture failures; `close()` during linger tears down promptly; rear-camera cache invalidation; non-default capture path timeout; 503 carries the capture error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
