### PR TITLE
Security hardening: require ROVER_API_KEY on all API/dashboard endpoints, lock down CORS via ALLOWED_ORIGINS   

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,7 @@
-# Shared secret required on every SDK API call (Authorization: Bearer ...,
-# and as ?key= for the dashboard page / feed / WebSocket clients that can't
-# set a header). This isn't a FrodoBots credential — pick any long random
-# string yourself, e.g.:
+# Shared secret required on every SDK API call (Authorization: Bearer ...).
+# The read-only /feed endpoint and /ws/data also accept ?key= because some
+# streaming clients cannot set a header. This isn't a FrodoBots credential —
+# it must be at least 32 characters; generate a random value, e.g.:
 #   python3 -c "import secrets; print(secrets.token_urlsafe(32))"
 #   openssl rand -base64 32
 # If left unset the server generates one at startup and logs it, but that

--- a/.env.sample
+++ b/.env.sample
@@ -1,56 +1,33 @@
-# Shared secret required on every SDK API call (Authorization: Bearer ...).
-# The read-only /feed endpoint and /ws/data also accept ?key= because some
-# streaming clients cannot set a header. This isn't a FrodoBots credential —
-# it must be at least 32 characters; generate a random value, e.g.:
-#   python3 -c "import secrets; print(secrets.token_urlsafe(32))"
-#   openssl rand -base64 32
-# If left unset the server generates one at startup and logs it, but that
-# value changes every restart, so set one explicitly for anything beyond a
-# quick local test — and set it before exposing port 8000 on a LAN/Docker
-# host, since that's the only thing standing between the network and a real
-# rover's controls.
-# ROVER_API_KEY=""
-# Cross-origin browser JS is denied by default. Only set this if a separately
-# hosted frontend needs cross-origin fetch access to this server — e.g.
-# examples/web/*.html, served via `python3 -m http.server` rather than opened
-# as a file:// page (browsers send Origin: null there, which CORS allowlists
-# can't reliably match). Comma-separated origins, e.g. "http://localhost:5500".
-# ALLOWED_ORIGINS=""
-# Your personal SDK access token, from https://my.frodobots.com/owner/settings
-# (Settings -> SDK Access Token, after completing bot activation).
+# FrodoBots credentials from https://my.frodobots.com/owner/settings
 SDK_API_TOKEN="3x4mpl3t0k4n"
-# The slug of the bot this token owns, also from that same settings page. Must
-# belong to the account SDK_API_TOKEN was issued for, or every request fails
-# with "Bot not found" / "Bot unavailable for SDK".
 BOT_SLUG="weld-arm-ultron"
+
+# Local password for this HTTP server. Do not reuse SDK_API_TOKEN.
+# Minimum 32 characters. Leave empty to generate one at startup.
+ROVER_API_KEY=""
+
+# Trusted browser origins, comma-separated. Empty blocks cross-origin access.
+ALLOWED_ORIGINS=""
+
 MISSION_SLUG="mission-ex4mpl3"
 MAP_ZOOM_LEVEL=18
 IMAGE_FORMAT="jpeg"
 IMAGE_QUALITY="0.8"
 FEED_JPEG_QUALITY="0.8"
-# How long the shared capture loop keeps running after the last /feed client
-# or /v2 snapshot poll, so steady polling always hits a warm frame cache.
-# Default: 10
+# Frame-cache linger in seconds (default: 10).
 # FEED_IDLE_LINGER_S=10
-# How long /v2/front|rear|screenshot waits for a fresh frame before failing
-# fast with 404/503 (a healthy camera answers in tens of milliseconds).
-# Default: 2
+# Fresh-frame timeout in seconds (default: 2).
 # V2_FRAME_TIMEOUT_S=2
-# Optional: Playwright manages its own Chromium. Set this only to use a
-# specific browser binary (e.g. real Google Chrome for H.264 streams).
+# Optional custom browser binary.
 # CHROME_EXECUTABLE_PATH="/path/to/chrome"
-# Bot type label ("mini", "mini_plus", "zero"). Informational only — rear
-# camera availability is detected automatically from the bot's streams.
+# Optional informational bot type: mini, mini_plus, or zero.
 # BOT_TYPE="mini"
-# Required for dashboard video when using pre-seeded channel tokens.
+# Optional pre-seeded dashboard video tokens.
 # SPECTATOR_USERID=""
 # SPECTATOR_RTC_TOKEN=""
-# Dead-man watchdog: deliver a confirmed stop when confirmed control delivery
-# goes stale for this many seconds (0 disables). Streaming clients: 0.5-1.
-# Default: 3
+# Control watchdog in seconds (0 disables; default: 3).
 # CONTROL_WATCHDOG_S=3
-# Maximum time lifecycle endpoints wait for a confirmed stop before returning
-# 503 and leaving the mission/control session open for continued recovery.
+# Safety-stop confirmation timeout in seconds (default: 12).
 # SAFETY_STOP_CONFIRM_TIMEOUT_S=12
 TTS_PROVIDER="edge"
 TTS_API_KEY=""

--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,27 @@
+# Shared secret required on every SDK API call (Authorization: Bearer ...,
+# and as ?key= for the dashboard page / feed / WebSocket clients that can't
+# set a header). This isn't a FrodoBots credential — pick any long random
+# string yourself, e.g.:
+#   python3 -c "import secrets; print(secrets.token_urlsafe(32))"
+#   openssl rand -base64 32
+# If left unset the server generates one at startup and logs it, but that
+# value changes every restart, so set one explicitly for anything beyond a
+# quick local test — and set it before exposing port 8000 on a LAN/Docker
+# host, since that's the only thing standing between the network and a real
+# rover's controls.
+# ROVER_API_KEY=""
+# Cross-origin browser JS is denied by default. Only set this if a separately
+# hosted frontend needs cross-origin fetch access to this server — e.g.
+# examples/web/*.html, served via `python3 -m http.server` rather than opened
+# as a file:// page (browsers send Origin: null there, which CORS allowlists
+# can't reliably match). Comma-separated origins, e.g. "http://localhost:5500".
+# ALLOWED_ORIGINS=""
+# Your personal SDK access token, from https://my.frodobots.com/owner/settings
+# (Settings -> SDK Access Token, after completing bot activation).
 SDK_API_TOKEN="3x4mpl3t0k4n"
+# The slug of the bot this token owns, also from that same settings page. Must
+# belong to the account SDK_API_TOKEN was issued for, or every request fails
+# with "Bot not found" / "Bot unavailable for SDK".
 BOT_SLUG="weld-arm-ultron"
 MISSION_SLUG="mission-ex4mpl3"
 MAP_ZOOM_LEVEL=18

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,7 @@ ENV PYTHONUNBUFFERED=1
 
 EXPOSE 8000
 
-CMD ["python3", "-m", "hypercorn", "main:app", "--bind", "0.0.0.0:8000"]
+# Loopback-only unless the operator explicitly opts into container-network
+# access with ROVER_BIND_HOST=0.0.0.0. docker-compose.yml does that internally
+# while still publishing the host port on 127.0.0.1 only.
+CMD ["sh", "-c", "exec python3 -m hypercorn main:app --bind \"${ROVER_BIND_HOST:-127.0.0.1}:8000\""]

--- a/README.md
+++ b/README.md
@@ -78,9 +78,10 @@ SDK_API_TOKEN=
 # with "Bot not found" / "Bot unavailable for SDK".
 BOT_SLUG=
 # Shared secret this server requires on every API call (Authorization: Bearer
-# ..., or ?key= for clients that can't set a header, like the dashboard page,
-# /feed, and WebSockets). Not a FrodoBots credential — pick any long random
-# string yourself, e.g. `python3 -c "import secrets; print(secrets.token_urlsafe(32))"`.
+# ...). The read-only /feed endpoint and /ws/data also accept ?key= because
+# some streaming clients cannot set a header. Not a FrodoBots credential — it
+# must be at least 32 characters; generate a random value, e.g.
+# `python3 -c "import secrets; print(secrets.token_urlsafe(32))"`.
 # Leaving it unset still works — the server generates one at startup and logs
 # it — but that value changes every restart, so set one explicitly here for
 # anything beyond a quick local test, and definitely before exposing port
@@ -136,7 +137,13 @@ playwright install chromium
 hypercorn main:app --reload
 ```
 
-4. Open the dashboard at `http://localhost:8000/?key=YOUR_ROVER_API_KEY` (the key the server logged on startup, or the one you set) to watch the live stream, follow the rover on the map, monitor telemetry and drive the bot. Every other endpoint needs the same key sent as `-H "Authorization: Bearer $ROVER_API_KEY"`.
+4. Open the dashboard at `http://localhost:8000` and enter the key the server logged on startup (or the one you set). The login exchanges it for an HttpOnly, same-site dashboard cookie, so the control secret does not appear in browser history or access logs. Machine API calls need the key sent as `-H "Authorization: Bearer $ROVER_API_KEY"`.
+
+### Docker network exposure
+
+The image binds to `127.0.0.1` by default. `docker-compose.yml` opts into the container interface internally but publishes port 8000 only on host loopback (`127.0.0.1:8000`). Replace its `ROVER_API_KEY` placeholder before starting it.
+
+To make a rover server reachable from the LAN, both changes must be explicit: set `ROVER_BIND_HOST=0.0.0.0` inside the container and publish `8000:8000` (or a specific trusted host address). Only do this with a strong `ROVER_API_KEY` and appropriate network firewalling.
 
 ## Dashboard
 
@@ -381,7 +388,7 @@ Query params:
 - `view`: `front` (default) or `rear` (bots with a rear camera; 404 otherwise)
 - `fps`: 1–30 (default 15)
 
-Needs the API key. Clients that can't set a custom header (a browser tab, `cv2.VideoCapture`) pass it as `?key=` instead — the server accepts either on GET endpoints.
+Needs the API key. Clients that can't set a custom header (a browser tab, `cv2.VideoCapture`) pass it as `?key=` instead. Query authentication is accepted only on this read-only `/feed` endpoint; state-changing endpoints always require a header.
 
 ```bash
 # Watch it in a browser:
@@ -445,7 +452,7 @@ Sample Response:
 
 ### WS /ws/data
 
-WebSocket stream of telemetry for real-time consumers (the dashboard uses it). Browser `WebSocket` clients can't set custom headers, so pass the API key as a query param — the same `?key=` used everywhere else: `ws://localhost:8000/ws/data?key=YOUR_ROVER_API_KEY`. On connect you receive a `snapshot` message with the latest telemetry (or `data: null` if none yet), then a `telemetry` message per rover update and a `status` heartbeat every 5 seconds:
+WebSocket stream of telemetry for real-time consumers (the dashboard uses it). Browser `WebSocket` clients can't set custom headers, so pass the API key as a query parameter: `ws://localhost:8000/ws/data?key=YOUR_ROVER_API_KEY`. Query credentials are limited to this WebSocket and the read-only `/feed` endpoint. On connect you receive a `snapshot` message with the latest telemetry (or `data: null` if none yet), then a `telemetry` message per rover update and a `status` heartbeat every 5 seconds:
 
 ```json
 { "type": "snapshot", "data": { ... }, "ingest_connected": true, "telemetry_age_s": 0.1 }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 2. Complete your Bot activation.
 
-3. After completing your bot activation. Get your SDK Access token in [here](https://my.frodobots.com/owner/settings).
+3. After completing your bot activation, get your SDK Access token and bot slug from the same page: [my.frodobots.com/owner/settings](https://my.frodobots.com/owner/settings). These become `SDK_API_TOKEN` and `BOT_SLUG` in your `.env` — they must belong to the same account, or every SDK request fails with "Bot not found".
 
 ## Software Requirements
 
@@ -70,8 +70,32 @@ More details about the bot sensors and actuators can be found [here](https://col
 1. Write once your .env variables provided by Frodobots team your SDK API key and the name of the bot you've got.
 
 ```bash
+# Your personal SDK access token, from https://my.frodobots.com/owner/settings
+# (Settings -> SDK Access Token, after completing bot activation).
 SDK_API_TOKEN=
+# The slug of the bot this token owns, also from that same settings page. Must
+# belong to the account SDK_API_TOKEN was issued for, or every request fails
+# with "Bot not found" / "Bot unavailable for SDK".
 BOT_SLUG=
+# Shared secret this server requires on every API call (Authorization: Bearer
+# ..., or ?key= for clients that can't set a header, like the dashboard page,
+# /feed, and WebSockets). Not a FrodoBots credential — pick any long random
+# string yourself, e.g. `python3 -c "import secrets; print(secrets.token_urlsafe(32))"`.
+# Leaving it unset still works — the server generates one at startup and logs
+# it — but that value changes every restart, so set one explicitly here for
+# anything beyond a quick local test, and definitely before exposing port
+# 8000 on a LAN/Docker host — it's the only thing gating a real rover's
+# controls at that point.
+ROVER_API_KEY=
+# Cross-origin browser JS (fetch/XHR from a page on a different origin) is
+# denied by default. Leave unset unless you're serving a frontend from
+# somewhere other than this server itself — e.g. examples/web/*.html need
+# their serving origin listed here (comma-separated), or the browser blocks
+# their requests with a valid key. Serve them with a local static server
+# (`python3 -m http.server 5500` from examples/web/) rather than opening the
+# file directly — browsers send Origin: null for file:// pages, which most
+# CORS setups (including ALLOWED_ORIGINS matching) can't allowlist reliably.
+# ALLOWED_ORIGINS=http://localhost:5500
 # Optional: use a specific browser binary instead of Playwright's Chromium
 # CHROME_EXECUTABLE_PATH=
 # Default value is MAP_ZOOM_LEVEL=18 https://wiki.openstreetmap.org/wiki/Zoom_levels
@@ -112,7 +136,7 @@ playwright install chromium
 hypercorn main:app --reload
 ```
 
-4. Open the dashboard at http://localhost:8000 to watch the live stream, follow the rover on the map, monitor telemetry and drive the bot.
+4. Open the dashboard at `http://localhost:8000/?key=YOUR_ROVER_API_KEY` (the key the server logged on startup, or the one you set) to watch the live stream, follow the rover on the map, monitor telemetry and drive the bot. Every other endpoint needs the same key sent as `-H "Authorization: Bearer $ROVER_API_KEY"`.
 
 ## Dashboard
 
@@ -145,6 +169,7 @@ With this endpoint you can send linear and angular values to move the bot, and c
 
 ```bash
 curl --location 'http://localhost:8000/control' \
+  -H "Authorization: Bearer $ROVER_API_KEY" \
 --header 'Content-Type: application/json' \
 --data '{
     "command": { "linear": 1, "angular": 1, "lamp": 0 }
@@ -170,7 +195,7 @@ Example response:
 With this endpoint you can retrieve the latest data from the bot. (e.g. battery level, position, etc.)
 
 ```bash
-curl --location 'http://localhost:8000/data'
+curl --location 'http://localhost:8000/data' -H "Authorization: Bearer $ROVER_API_KEY"
 ```
 
 Example Response:
@@ -223,7 +248,7 @@ This endpoint captures the requested views and returns each image as base64. The
 This endpoint accepts a list of view types as a query parameter (view_types). Valid view types are rear, map, and front. If no view types are provided, it will return all three by default.
 
 ```bash
-curl --location 'http://localhost:8000/screenshot?view_types=rear,map,front'
+curl --location 'http://localhost:8000/screenshot?view_types=rear,map,front' -H "Authorization: Bearer $ROVER_API_KEY"
 ```
 
 Example Response:
@@ -238,7 +263,7 @@ Example Response:
 ```
 
 ```bash
-curl --location 'http://localhost:8000/screenshot?view_types=rear'
+curl --location 'http://localhost:8000/screenshot?view_types=rear' -H "Authorization: Bearer $ROVER_API_KEY"
 ```
 
 Example Response:
@@ -261,7 +286,7 @@ You can parametrize the image quality between 0.1 and 1.0, and the format betwee
 > **Performance trap**: `/v2/*` shares the warm frame cache with `/feed` only in the default configuration (`IMAGE_FORMAT=jpeg` with `IMAGE_QUALITY` equal to `FEED_JPEG_QUALITY`). Setting a different format or quality silently switches `/v2/*` to an uncached per-request capture path, which is significantly slower under polling. If you poll for frames, keep the defaults.
 
 ```bash
-curl --location 'http://localhost:8000/v2/screenshot'
+curl --location 'http://localhost:8000/v2/screenshot' -H "Authorization: Bearer $ROVER_API_KEY"
 ```
 
 Example Response:
@@ -283,7 +308,7 @@ This endpoint allows you to retrieve the latest frame emitted from the bot's fro
 You can parametrize the image quality between 0.1 and 1.0, and the format between jpeg, png and webp, using the IMAGE_QUALITY and IMAGE_FORMAT environment variables.
 
 ```bash
-curl --location 'http://localhost:8000/v2/front'
+curl --location 'http://localhost:8000/v2/front' -H "Authorization: Bearer $ROVER_API_KEY"
 ```
 
 Example Response:
@@ -302,7 +327,7 @@ This endpoint allows you to retrieve the latest frame emitted from the bot's rea
 You can parametrize the image quality between 0.1 and 1.0, and the format between jpeg, png and webp, using the IMAGE_QUALITY and IMAGE_FORMAT environment variables.
 
 ```bash
-curl --location 'http://localhost:8000/v2/rear'
+curl --location 'http://localhost:8000/v2/rear' -H "Authorization: Bearer $ROVER_API_KEY"
 ```
 
 Example Response:
@@ -324,6 +349,7 @@ Supports two TTS providers, configurable via environment variables:
 
 ```bash
 curl --location 'http://localhost:8000/speak' \
+  -H "Authorization: Bearer $ROVER_API_KEY" \
 --header 'Content-Type: application/json' \
 --data '{
     "text": "Hello, I am your rover"
@@ -355,15 +381,17 @@ Query params:
 - `view`: `front` (default) or `rear` (bots with a rear camera; 404 otherwise)
 - `fps`: 1–30 (default 15)
 
+Needs the API key. Clients that can't set a custom header (a browser tab, `cv2.VideoCapture`) pass it as `?key=` instead — the server accepts either on GET endpoints.
+
 ```bash
 # Watch it in a browser:
-open 'http://localhost:8000/feed?view=front&fps=15'
+open 'http://localhost:8000/feed?view=front&fps=15&key=YOUR_ROVER_API_KEY'
 ```
 
 ```python
 # Or consume it from OpenCV / ROS2:
 import cv2
-cap = cv2.VideoCapture("http://localhost:8000/feed?view=front&fps=15")
+cap = cv2.VideoCapture("http://localhost:8000/feed?view=front&fps=15&key=YOUR_ROVER_API_KEY")
 ok, frame = cap.read()
 ```
 
@@ -380,7 +408,7 @@ Lightweight health endpoint for the SDK pipeline — no side effects, safe to po
 Sample Request:
 
 ```bash
-curl --location 'http://localhost:8000/status'
+curl --location 'http://localhost:8000/status' -H "Authorization: Bearer $ROVER_API_KEY"
 ```
 
 Sample Response:
@@ -417,7 +445,7 @@ Sample Response:
 
 ### WS /ws/data
 
-WebSocket stream of telemetry for real-time consumers (the dashboard uses it). On connect you receive a `snapshot` message with the latest telemetry (or `data: null` if none yet), then a `telemetry` message per rover update and a `status` heartbeat every 5 seconds:
+WebSocket stream of telemetry for real-time consumers (the dashboard uses it). Browser `WebSocket` clients can't set custom headers, so pass the API key as a query param — the same `?key=` used everywhere else: `ws://localhost:8000/ws/data?key=YOUR_ROVER_API_KEY`. On connect you receive a `snapshot` message with the latest telemetry (or `data: null` if none yet), then a `telemetry` message per rover update and a `status` heartbeat every 5 seconds:
 
 ```json
 { "type": "snapshot", "data": { ... }, "ingest_connected": true, "telemetry_age_s": 0.1 }
@@ -448,7 +476,7 @@ Lists the available missions for the bot you are connected to (the one set in `B
 `Note: Missions are only listed for remote bots (the deployed Earth Rovers you drive remotely). Personal bots do not have missions, so this endpoint will return an empty list for them.`
 
 ```bash
-curl --location 'http://localhost:8000/missions'
+curl --location 'http://localhost:8000/missions' -H "Authorization: Bearer $ROVER_API_KEY"
 ```
 
 Example Response:
@@ -468,7 +496,7 @@ Example Response:
 ### POST /start-mission
 
 ```bash
-curl --location --request POST 'http://localhost:8000/start-mission'
+curl --location --request POST 'http://localhost:8000/start-mission' -H "Authorization: Bearer $ROVER_API_KEY"
 ```
 
 Successful Response (Code: 200)
@@ -494,7 +522,7 @@ Unsuccessful Response (Code: 400)
 With this endpoint you can retrieve the list of checkpoints for the mission. And the latest checkpoint that was scanned by the bot. If you scan the first checkpoint, the latest_scanned_checkpoint will be 1. If you scan the last checkpoint, the latest_scanned_checkpoint will be the highest sequence number and the mission will be completed.
 
 ```bash
-curl --location 'http://localhost:8000/checkpoints-list'
+curl --location 'http://localhost:8000/checkpoints-list' -H "Authorization: Bearer $ROVER_API_KEY"
 ```
 
 Example Response:
@@ -531,6 +559,7 @@ With this endpoint you can send the checkpoint that was scanned by the bot.
 
 ```bash
 curl -X POST 'http://localhost:8000/checkpoint-reached' \
+  -H "Authorization: Bearer $ROVER_API_KEY" \
 --header 'Content-Type: application/json' \
 --data '{}'
 ```
@@ -567,7 +596,7 @@ In case you get stucked and don't want to lose your progress, you can use the /s
 `⚠️  This endpoint should only be used in case of emergency. If you run this endpoint you will lose all your progress during the mission.`
 
 ```bash
-curl --location --request POST 'http://localhost:8000/end-mission'
+curl --location --request POST 'http://localhost:8000/end-mission' -H "Authorization: Bearer $ROVER_API_KEY"
 ```
 
 Example Response:
@@ -583,7 +612,7 @@ Example Response:
 With this endpoint you can retrieve the missions history of the bot you've been riding.
 
 ```bash
-curl --location 'http://localhost:8000/missions-history'
+curl --location 'http://localhost:8000/missions-history' -H "Authorization: Bearer $ROVER_API_KEY"
 ```
 
 Example Response:
@@ -614,7 +643,7 @@ The Interventions API allows you to manage interventions during bot rides. An in
 Start a new intervention for the current bot ride. The bot's current position (latitude and longitude) will be automatically recorded.
 
 ```bash
-curl -X POST 'http://localhost:8000/interventions/start'
+curl -X POST 'http://localhost:8000/interventions/start' -H "Authorization: Bearer $ROVER_API_KEY"
 ```
 
 Successful Response (Code: 200)
@@ -631,7 +660,7 @@ Successful Response (Code: 200)
 End an active intervention for the current bot ride. The bot's current position (latitude and longitude) will be automatically recorded.
 
 ```bash
-curl -X POST 'http://localhost:8000/interventions/end'
+curl -X POST 'http://localhost:8000/interventions/end' -H "Authorization: Bearer $ROVER_API_KEY"
 ```
 
 Successful Response (Code: 200)
@@ -655,7 +684,7 @@ Unsuccessful Response (Code: 400)
 Retrieve the history of interventions for the current bot.
 
 ```bash
-curl --location 'http://localhost:8000/interventions/history'
+curl --location 'http://localhost:8000/interventions/history' -H "Authorization: Bearer $ROVER_API_KEY"
 ```
 
 Example Response:

--- a/browser_service.py
+++ b/browser_service.py
@@ -3,6 +3,7 @@ import logging
 import os
 import time
 from typing import Optional
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from dotenv import load_dotenv
 from playwright.async_api import Error as PlaywrightError
@@ -81,12 +82,16 @@ class BrowserService:
             return self._page
 
     def _sdk_page_url(self) -> str:
-        import main as _main
-
-        if "key=" in SDK_PAGE_URL:
-            return SDK_PAGE_URL
-        separator = "&" if "?" in SDK_PAGE_URL else "?"
-        return f"{SDK_PAGE_URL}{separator}key={_main.ROVER_API_KEY}"
+        """Drop legacy URL credentials before the browser navigates."""
+        parts = urlsplit(SDK_PAGE_URL)
+        query = urlencode(
+            [
+                (name, value)
+                for name, value in parse_qsl(parts.query, keep_blank_values=True)
+                if name != "key"
+            ]
+        )
+        return urlunsplit((parts.scheme, parts.netloc, parts.path, query, parts.fragment))
 
     async def _launch(self):
         self._ready = False
@@ -138,14 +143,34 @@ class BrowserService:
                         " stream may need H.264: install Chrome or set"
                         " CHROME_EXECUTABLE_PATH to a codec-capable browser"
                     )
+            # Import here to avoid the main -> BrowserService import cycle.
+            # Scope the HttpOnly cookie to the SDK origin. A browser-wide
+            # Authorization header would leak the key to third-party requests
+            # made by the page (map tiles, RTC services, and similar).
+            import main as _main
+
             self._context = await self._browser.new_context(
                 viewport=self._viewport,
                 extra_http_headers={"Accept-Language": "en-US,en;q=0.9"},
             )
-            self._page = await self._context.new_page()
-            await self._page.goto(
-                self._sdk_page_url(), wait_until="domcontentloaded"
+            sdk_page_url = self._sdk_page_url()
+            sdk_origin = urlsplit(sdk_page_url)
+            if sdk_origin.scheme not in ("http", "https") or not sdk_origin.netloc:
+                raise RuntimeError("SDK_PAGE_URL must be an absolute http(s) URL")
+            await self._context.add_cookies(
+                [
+                    {
+                        "name": "rover_key",
+                        "value": _main.ROVER_API_KEY,
+                        "url": f"{sdk_origin.scheme}://{sdk_origin.netloc}",
+                        "httpOnly": True,
+                        "secure": sdk_origin.scheme == "https",
+                        "sameSite": "Strict",
+                    }
+                ]
             )
+            self._page = await self._context.new_page()
+            await self._page.goto(sdk_page_url, wait_until="domcontentloaded")
             await self._page.click("#join")
             # Control and telemetry must remain available when a camera is
             # offline. Wait for RTM readiness, not for a video DOM element.

--- a/browser_service.py
+++ b/browser_service.py
@@ -80,6 +80,14 @@ class BrowserService:
             await self._launch()
             return self._page
 
+    def _sdk_page_url(self) -> str:
+        import main as _main
+
+        if "key=" in SDK_PAGE_URL:
+            return SDK_PAGE_URL
+        separator = "&" if "?" in SDK_PAGE_URL else "?"
+        return f"{SDK_PAGE_URL}{separator}key={_main.ROVER_API_KEY}"
+
     async def _launch(self):
         self._ready = False
         try:
@@ -135,7 +143,9 @@ class BrowserService:
                 extra_http_headers={"Accept-Language": "en-US,en;q=0.9"},
             )
             self._page = await self._context.new_page()
-            await self._page.goto(SDK_PAGE_URL, wait_until="domcontentloaded")
+            await self._page.goto(
+                self._sdk_page_url(), wait_until="domcontentloaded"
+            )
             await self._page.click("#join")
             # Control and telemetry must remain available when a camera is
             # offline. Wait for RTM readiness, not for a video DOM element.

--- a/dashboard.html
+++ b/dashboard.html
@@ -11,15 +11,6 @@
   <body>
     <script>
       window.DASH = {{ dashboard_config }};
-      // The key only needs to ride in the URL for the very first load — the
-      // server just set a cookie for reloads. Drop it from the address bar,
-      // browser history and any Referer header sent from here on.
-      if (window.DASH.apiKey && location.search.includes("key=")) {
-        var params = new URLSearchParams(location.search);
-        params.delete("key");
-        var rest = params.toString();
-        history.replaceState(null, "", location.pathname + (rest ? "?" + rest : ""));
-      }
     </script>
 
     <header class="topbar">
@@ -245,8 +236,8 @@
 
     <footer class="footer">
       <a href="/sdk">SDK page</a>
-      <a id="footer-data" href="/data">/data</a>
-      <a id="footer-status" href="/status">/status</a>
+      <span>/data</span>
+      <span>/status</span>
     </footer>
 
     <script src="/static/vendor/leaflet/leaflet.js"></script>

--- a/dashboard.html
+++ b/dashboard.html
@@ -11,6 +11,15 @@
   <body>
     <script>
       window.DASH = {{ dashboard_config }};
+      // The key only needs to ride in the URL for the very first load — the
+      // server just set a cookie for reloads. Drop it from the address bar,
+      // browser history and any Referer header sent from here on.
+      if (window.DASH.apiKey && location.search.includes("key=")) {
+        var params = new URLSearchParams(location.search);
+        params.delete("key");
+        var rest = params.toString();
+        history.replaceState(null, "", location.pathname + (rest ? "?" + rest : ""));
+      }
     </script>
 
     <header class="topbar">
@@ -235,10 +244,9 @@
     </main>
 
     <footer class="footer">
-      <a href="/docs">API docs</a>
       <a href="/sdk">SDK page</a>
-      <a href="/data">/data</a>
-      <a href="/status">/status</a>
+      <a id="footer-data" href="/data">/data</a>
+      <a id="footer-status" href="/status">/status</a>
     </footer>
 
     <script src="/static/vendor/leaflet/leaflet.js"></script>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,11 @@ services:
       - DEBUG=true
       - BOT_SLUG=yout-bot-name
       - SDK_API_TOKEN=y0ur4p1tok3n
+      # Required: this port is published to the host (and reachable over the
+      # LAN), so every API call needs this shared secret. Set it explicitly —
+      # an auto-generated key would change on every container restart. The
+      # server refuses to start if this placeholder is still in place.
+      - ROVER_API_KEY=change-me-to-a-long-random-value
       - MAP_ZOOM_LEVEL=18
       - IMAGE_FORMAT=jpeg
       - IMAGE_QUALITY=0.8

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,13 @@ services:
       # an auto-generated key would change on every container restart. The
       # server refuses to start if this placeholder is still in place.
       - ROVER_API_KEY=change-me-to-a-long-random-value
+      # Listen on the container interface so Docker can forward the port. The
+      # host-side mapping below remains loopback-only by default.
+      - ROVER_BIND_HOST=0.0.0.0
       - MAP_ZOOM_LEVEL=18
       - IMAGE_FORMAT=jpeg
       - IMAGE_QUALITY=0.8
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     volumes:
       - ./screenshots:/app/screenshots

--- a/examples/basics/01_basic_movement.py
+++ b/examples/basics/01_basic_movement.py
@@ -9,15 +9,18 @@ This example demonstrates the fundamental movement controls:
 The rover uses linear (-1 to 1) and angular (-1 to 1) values for control.
 """
 
-import requests
 import time
 
 BASE_URL = "http://localhost:8000"
 
+from _client import rover_session
+
+SESSION = rover_session()
+
 
 def send_command(linear: float, angular: float, lamp: int = 0):
     """Send a movement command to the rover."""
-    response = requests.post(
+    response = SESSION.post(
         f"{BASE_URL}/control",
         json={"command": {"linear": linear, "angular": angular, "lamp": lamp}},
     )

--- a/examples/basics/02_diagonal_movement.py
+++ b/examples/basics/02_diagonal_movement.py
@@ -8,15 +8,18 @@ By combining forward/backward with left/right, the rover
 can follow curved paths and arcs.
 """
 
-import requests
 import time
 
 BASE_URL = "http://localhost:8000"
 
+from _client import rover_session
+
+SESSION = rover_session()
+
 
 def send_command(linear: float, angular: float, lamp: int = 0):
     """Send a movement command to the rover."""
-    response = requests.post(
+    response = SESSION.post(
         f"{BASE_URL}/control",
         json={"command": {"linear": linear, "angular": angular, "lamp": lamp}},
     )

--- a/examples/basics/03_speed_control.py
+++ b/examples/basics/03_speed_control.py
@@ -7,15 +7,18 @@ smooth acceleration/deceleration patterns.
 Speed values range from -1.0 (full reverse) to 1.0 (full forward).
 """
 
-import requests
 import time
 
 BASE_URL = "http://localhost:8000"
 
+from _client import rover_session
+
+SESSION = rover_session()
+
 
 def send_command(linear: float, angular: float, lamp: int = 0):
     """Send a movement command to the rover."""
-    response = requests.post(
+    response = SESSION.post(
         f"{BASE_URL}/control",
         json={"command": {"linear": linear, "angular": angular, "lamp": lamp}},
     )

--- a/examples/basics/04_lamp_control.py
+++ b/examples/basics/04_lamp_control.py
@@ -7,15 +7,18 @@ while stationary or while moving.
 Lamp values: 0 = off, 1 = on
 """
 
-import requests
 import time
 
 BASE_URL = "http://localhost:8000"
 
+from _client import rover_session
+
+SESSION = rover_session()
+
 
 def send_command(linear: float, angular: float, lamp: int = 0):
     """Send a movement command to the rover."""
-    response = requests.post(
+    response = SESSION.post(
         f"{BASE_URL}/control",
         json={"command": {"linear": linear, "angular": angular, "lamp": lamp}},
     )

--- a/examples/basics/05_telemetry_monitoring.py
+++ b/examples/basics/05_telemetry_monitoring.py
@@ -11,16 +11,19 @@ This example shows how to read and monitor rover telemetry data:
 - Motor RPMs
 """
 
-import requests
 import time
 import json
 
 BASE_URL = "http://localhost:8000"
 
+from _client import rover_session
+
+SESSION = rover_session()
+
 
 def get_telemetry():
     """Fetch current telemetry data from the rover."""
-    response = requests.get(f"{BASE_URL}/data")
+    response = SESSION.get(f"{BASE_URL}/data")
     return response.json()
 
 

--- a/examples/basics/06_dual_camera_stream.py
+++ b/examples/basics/06_dual_camera_stream.py
@@ -15,6 +15,10 @@ import cv2
 
 BASE_URL = "http://localhost:8000"
 
+from _client import rover_auth_headers
+
+HEADERS = rover_auth_headers()
+
 
 async def fetch_dual_frames(session: aiohttp.ClientSession) -> tuple:
     """Fetch both camera frames in a single request (optimized)."""
@@ -39,7 +43,7 @@ async def display_dual_stream():
     print("Starting dual camera stream...")
     print("Press 'q' to quit")
 
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(headers=HEADERS) as session:
         frame_count = 0
         start_time = asyncio.get_event_loop().time()
 
@@ -95,7 +99,7 @@ async def capture_snapshot():
     """Capture and save a single snapshot from both cameras."""
     print("Capturing snapshot...")
 
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(headers=HEADERS) as session:
         front_b64, rear_b64, timestamp = await fetch_dual_frames(session)
 
         front_frame = decode_frame(front_b64)

--- a/examples/basics/07_square_pattern.py
+++ b/examples/basics/07_square_pattern.py
@@ -7,15 +7,18 @@ by alternating between forward movement and 90-degree turns.
 Great for testing movement precision and calibration.
 """
 
-import requests
 import time
 
 BASE_URL = "http://localhost:8000"
 
+from _client import rover_session
+
+SESSION = rover_session()
+
 
 def send_command(linear: float, angular: float, lamp: int = 0):
     """Send a movement command to the rover."""
-    response = requests.post(
+    response = SESSION.post(
         f"{BASE_URL}/control",
         json={"command": {"linear": linear, "angular": angular, "lamp": lamp}},
     )

--- a/examples/basics/08_circle_pattern.py
+++ b/examples/basics/08_circle_pattern.py
@@ -7,17 +7,20 @@ by combining forward movement with continuous turning.
 Demonstrates smooth curved motion control.
 """
 
-import requests
 import time
 import math
 
 BASE_URL = "http://localhost:8000"
+
+from _client import rover_session
+
+SESSION = rover_session()
 CONTROL_RATE_HZ = 10.0
 
 
 def send_command(linear: float, angular: float, lamp: int = 0):
     """Send a movement command to the rover."""
-    response = requests.post(
+    response = SESSION.post(
         f"{BASE_URL}/control",
         json={"command": {"linear": linear, "angular": angular, "lamp": lamp}},
     )

--- a/examples/basics/09_keyboard_teleop.py
+++ b/examples/basics/09_keyboard_teleop.py
@@ -30,6 +30,10 @@ except ImportError:
 
 BASE_URL = "http://localhost:8000"
 
+from _client import rover_session
+
+SESSION = rover_session()
+
 
 class RoverController:
     def __init__(self):
@@ -42,7 +46,7 @@ class RoverController:
     def send_command(self):
         """Send current state to rover."""
         try:
-            requests.post(
+            SESSION.post(
                 f"{BASE_URL}/control",
                 json={"command": {
                     "linear": self.linear,
@@ -130,7 +134,7 @@ def main():
         pass
     finally:
         # Stop rover on exit
-        requests.post(
+        SESSION.post(
             f"{BASE_URL}/control",
             json={"command": {"linear": 0, "angular": 0, "lamp": 0}}
         )

--- a/examples/basics/10_mission_control.py
+++ b/examples/basics/10_mission_control.py
@@ -8,17 +8,20 @@ This example demonstrates the mission and checkpoint system:
 - Viewing mission history
 """
 
-import requests
 import time
 import json
 
 BASE_URL = "http://localhost:8000"
 
+from _client import rover_session
+
+SESSION = rover_session()
+
 
 def start_mission():
     """Start a new mission."""
     print("Starting mission...")
-    response = requests.post(f"{BASE_URL}/start-mission")
+    response = SESSION.post(f"{BASE_URL}/start-mission")
     result = response.json()
     print(f"  Response: {json.dumps(result, indent=2)}")
     return result
@@ -27,7 +30,7 @@ def start_mission():
 def end_mission():
     """End the current mission."""
     print("Ending mission...")
-    response = requests.post(f"{BASE_URL}/end-mission")
+    response = SESSION.post(f"{BASE_URL}/end-mission")
     result = response.json()
     print(f"  Response: {json.dumps(result, indent=2)}")
     return result
@@ -36,7 +39,7 @@ def end_mission():
 def get_checkpoints():
     """Get the list of checkpoints for the current mission."""
     print("Fetching checkpoints...")
-    response = requests.get(f"{BASE_URL}/checkpoints-list")
+    response = SESSION.get(f"{BASE_URL}/checkpoints-list")
     result = response.json()
     if isinstance(result, dict) and "checkpoints_list" in result:
         return result.get("checkpoints_list", []), result.get("latest_scanned_checkpoint")
@@ -80,7 +83,7 @@ def _to_float(value, default=0.0):
 def mark_checkpoint_reached():
     """Mark the current checkpoint as reached."""
     print("Marking checkpoint as reached...")
-    response = requests.post(f"{BASE_URL}/checkpoint-reached")
+    response = SESSION.post(f"{BASE_URL}/checkpoint-reached")
     result = response.json()
     print(f"  Response: {json.dumps(result, indent=2)}")
     return result
@@ -89,7 +92,7 @@ def mark_checkpoint_reached():
 def get_mission_history():
     """Get the history of past missions."""
     print("Fetching mission history...")
-    response = requests.get(f"{BASE_URL}/missions-history")
+    response = SESSION.get(f"{BASE_URL}/missions-history")
     result = response.json()
     return result
 
@@ -117,7 +120,7 @@ def display_mission_history(history: list):
 
 def send_command(linear: float, angular: float):
     """Send movement command."""
-    requests.post(
+    SESSION.post(
         f"{BASE_URL}/control",
         json={"command": {"linear": linear, "angular": angular, "lamp": 0}}
     )
@@ -133,7 +136,7 @@ def navigate_to_checkpoint(checkpoint: dict):
     print(f"\nNavigating to checkpoint: {checkpoint.get('name', 'Unknown')}")
 
     # Get current position
-    response = requests.get(f"{BASE_URL}/data")
+    response = SESSION.get(f"{BASE_URL}/data")
     data = response.json()
     current_lat = _to_float(data.get("latitude", data.get("lat", 0)))
     current_lon = _to_float(data.get("longitude", data.get("lon", 0)))

--- a/examples/basics/11_intervention_tracking.py
+++ b/examples/basics/11_intervention_tracking.py
@@ -9,18 +9,21 @@ This example demonstrates the intervention management system:
 Interventions track when human operators take control of the rover.
 """
 
-import requests
 import time
 import json
 from datetime import datetime
 
 BASE_URL = "http://localhost:8000"
 
+from _client import rover_session
+
+SESSION = rover_session()
+
 
 def start_intervention():
     """Start an intervention period."""
     print("Starting intervention...")
-    response = requests.post(f"{BASE_URL}/interventions/start")
+    response = SESSION.post(f"{BASE_URL}/interventions/start")
     result = response.json()
     print(f"  Response: {json.dumps(result, indent=2)}")
     return result
@@ -29,7 +32,7 @@ def start_intervention():
 def end_intervention():
     """End the current intervention period."""
     print("Ending intervention...")
-    response = requests.post(f"{BASE_URL}/interventions/end")
+    response = SESSION.post(f"{BASE_URL}/interventions/end")
     result = response.json()
     print(f"  Response: {json.dumps(result, indent=2)}")
     return result
@@ -38,7 +41,7 @@ def end_intervention():
 def get_intervention_history():
     """Get the history of interventions."""
     print("Fetching intervention history...")
-    response = requests.get(f"{BASE_URL}/interventions/history")
+    response = SESSION.get(f"{BASE_URL}/interventions/history")
     result = response.json()
     return result
 
@@ -73,7 +76,7 @@ def display_intervention_history(history: list):
 
 def send_command(linear: float, angular: float, lamp: int = 0):
     """Send movement command."""
-    requests.post(
+    SESSION.post(
         f"{BASE_URL}/control",
         json={"command": {"linear": linear, "angular": angular, "lamp": lamp}}
     )

--- a/examples/basics/12_video_recording.py
+++ b/examples/basics/12_video_recording.py
@@ -17,6 +17,10 @@ from datetime import datetime
 
 BASE_URL = "http://localhost:8000"
 
+from _client import rover_auth_headers
+
+HEADERS = rover_auth_headers()
+
 
 async def fetch_frames(session: aiohttp.ClientSession) -> tuple:
     """Fetch camera frames."""
@@ -62,7 +66,7 @@ async def record_video(
     rear_writer = None
     frame_count = 0
 
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(headers=HEADERS) as session:
         start_time = time.time()
 
         while time.time() - start_time < duration:
@@ -150,7 +154,7 @@ async def timelapse_capture(
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     frame_num = 0
 
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(headers=HEADERS) as session:
         start_time = time.time()
 
         while time.time() - start_time < duration:

--- a/examples/basics/13_async_control.py
+++ b/examples/basics/13_async_control.py
@@ -17,6 +17,10 @@ import cv2
 
 BASE_URL = "http://localhost:8000"
 
+from _client import rover_auth_headers
+
+HEADERS = rover_auth_headers()
+
 
 async def send_command_async(session: aiohttp.ClientSession,
                               linear: float, angular: float, lamp: int = 0):
@@ -134,7 +138,7 @@ async def concurrent_control_and_monitor():
 
     stop_event = asyncio.Event()
 
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(headers=HEADERS) as session:
         # Create background tasks
         telemetry_task = asyncio.create_task(
             telemetry_monitor(session, stop_event, interval=1.0)
@@ -162,7 +166,7 @@ async def parallel_data_fetch():
     """Fetch multiple data sources in parallel."""
     print("=== Parallel Data Fetch Demo ===\n")
 
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(headers=HEADERS) as session:
         # Fetch telemetry and frames in parallel
         telemetry_coro = get_telemetry_async(session)
         frames_coro = get_frames_async(session)
@@ -195,7 +199,7 @@ async def complex_maneuver():
     """Execute a complex maneuver with precise timing."""
     print("=== Complex Maneuver Demo ===\n")
 
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(headers=HEADERS) as session:
         # Execute multiple timed movements
         print("Executing complex maneuver...")
 

--- a/examples/basics/14_obstacle_simulation.py
+++ b/examples/basics/14_obstacle_simulation.py
@@ -8,16 +8,19 @@ Note: This is a simulation/demonstration. Real obstacle detection
 would require additional sensors (LIDAR, ultrasonic, etc.).
 """
 
-import requests
 import time
 import random
 
 BASE_URL = "http://localhost:8000"
 
+from _client import rover_session
+
+SESSION = rover_session()
+
 
 def send_command(linear: float, angular: float, lamp: int = 0):
     """Send movement command."""
-    requests.post(
+    SESSION.post(
         f"{BASE_URL}/control",
         json={"command": {"linear": linear, "angular": angular, "lamp": lamp}}
     )
@@ -30,7 +33,7 @@ def stop():
 
 def get_telemetry() -> dict:
     """Get current telemetry."""
-    response = requests.get(f"{BASE_URL}/data")
+    response = SESSION.get(f"{BASE_URL}/data")
     return response.json()
 
 

--- a/examples/basics/15_waypoint_navigation.py
+++ b/examples/basics/15_waypoint_navigation.py
@@ -10,16 +10,19 @@ This example demonstrates GPS-based waypoint navigation:
 Note: Requires accurate GPS data from the rover.
 """
 
-import requests
 import time
 import math
 
 BASE_URL = "http://localhost:8000"
 
+from _client import rover_session
+
+SESSION = rover_session()
+
 
 def send_command(linear: float, angular: float, lamp: int = 0):
     """Send movement command."""
-    requests.post(
+    SESSION.post(
         f"{BASE_URL}/control",
         json={"command": {"linear": linear, "angular": angular, "lamp": lamp}}
     )
@@ -32,7 +35,7 @@ def stop():
 
 def get_telemetry() -> dict:
     """Get current telemetry."""
-    response = requests.get(f"{BASE_URL}/data")
+    response = SESSION.get(f"{BASE_URL}/data")
     return response.json()
 
 

--- a/examples/basics/17_speak.py
+++ b/examples/basics/17_speak.py
@@ -11,14 +11,17 @@ Usage:
 
 import sys
 import time
-import requests
 
 BASE_URL = "http://localhost:8000"
+
+from _client import rover_session
+
+SESSION = rover_session()
 
 
 def speak(text: str) -> dict:
     """Send text to the rover's speaker via TTS."""
-    response = requests.post(f"{BASE_URL}/speak", json={"text": text})
+    response = SESSION.post(f"{BASE_URL}/speak", json={"text": text})
     response.raise_for_status()
     return response.json()
 

--- a/examples/basics/_client.py
+++ b/examples/basics/_client.py
@@ -1,0 +1,30 @@
+"""Authenticated HTTP helpers shared by the basic examples."""
+
+import os
+
+import requests
+from dotenv import load_dotenv
+
+
+load_dotenv()
+
+
+def rover_api_key() -> str:
+    """Return the local rover-server key or fail before sending a request."""
+    key = os.getenv("ROVER_API_KEY", "")
+    if not key:
+        raise RuntimeError(
+            "ROVER_API_KEY is not set. Add the key printed by the SDK server "
+            "to your environment or .env file."
+        )
+    return key
+
+
+def rover_auth_headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {rover_api_key()}"}
+
+
+def rover_session() -> requests.Session:
+    session = requests.Session()
+    session.headers.update(rover_auth_headers())
+    return session

--- a/examples/benchmarks/latency_probe.py
+++ b/examples/benchmarks/latency_probe.py
@@ -21,11 +21,15 @@ Usage:
 
 import argparse
 import csv
+import os
 import signal
 import sys
 import time
 
 import requests
+
+ROVER_API_KEY = os.environ.get("ROVER_API_KEY", "")
+AUTH_HEADERS = {"Authorization": f"Bearer {ROVER_API_KEY}"} if ROVER_API_KEY else {}
 
 SUMMARY_INTERVAL_S = 30.0
 
@@ -89,13 +93,19 @@ def poll_v2(args, stats: Stats, writer):
     frame_key = "front_frame"
     url = args.sdk_url.rstrip("/") + endpoint
     session = requests.Session() if args.session else requests
+    if args.session:
+        session.headers.update(AUTH_HEADERS)
     interval = 1.0 / args.rate
     deadline = time.monotonic()
     while True:
         started = time.monotonic()
         status, frame_timestamp = "exc", None
         try:
-            response = session.get(url, timeout=args.timeout)
+            response = session.get(
+                url,
+                timeout=args.timeout,
+                headers=None if args.session else AUTH_HEADERS,
+            )
             status = str(response.status_code)
             elapsed = time.monotonic() - started
             if response.status_code == 200:
@@ -145,7 +155,9 @@ def stream_feed(args, stats: Stats, writer):
     boundary = b"--frame"
     while True:
         try:
-            with requests.get(url, stream=True, timeout=(5, args.timeout)) as response:
+            with requests.get(
+                url, stream=True, timeout=(5, args.timeout), headers=AUTH_HEADERS
+            ) as response:
                 if response.status_code != 200:
                     stats.record_error(str(response.status_code))
                     print(f"/feed HTTP {response.status_code}: {response.text[:120]}")

--- a/examples/openclaw/AGENTS.md
+++ b/examples/openclaw/AGENTS.md
@@ -12,7 +12,8 @@ You are a rover controller agent. You control a physical Earth Rover robot throu
 6. **Always send a stop command** after every movement command (linear/angular). Never leave the rover moving.
 7. **Use safe speeds**: default linear speed 0.3–0.5, angular speed 0.3–0.4. Never exceed 0.7.
 8. **Never start, stop, or restart the server**. The human operator manages the server. If it's not running, tell the user and wait.
-9. You may check if the server is running: `curl -s http://localhost:8000/data`
+9. You may check if the server is running: `curl -s http://localhost:8000/data -H "Authorization: Bearer $ROVER_API_KEY"`
+10. **Every request must include** `-H "Authorization: Bearer $ROVER_API_KEY"` — the server rejects unauthenticated requests.
 
 ## API Reference
 
@@ -97,35 +98,40 @@ GET /interventions/history
 
 ## Example curl Commands
 
+Every request needs the server's `ROVER_API_KEY` as a bearer token. Export it once:
+```bash
+export ROVER_API_KEY="<the key printed by the server on startup, or set in its .env>"
+```
+
 Check status:
 ```bash
-curl -s http://localhost:8000/data | jq .
+curl -s http://localhost:8000/data -H "Authorization: Bearer $ROVER_API_KEY" | jq .
 ```
 
 Move forward:
 ```bash
-curl -s -X POST http://localhost:8000/control -H "Content-Type: application/json" -d '{"command": {"linear": 0.4, "angular": 0}}'
+curl -s -X POST http://localhost:8000/control -H "Content-Type: application/json" -H "Authorization: Bearer $ROVER_API_KEY" -d '{"command": {"linear": 0.4, "angular": 0}}'
 sleep 1
-curl -s -X POST http://localhost:8000/control -H "Content-Type: application/json" -d '{"command": {"linear": 0, "angular": 0}}'
+curl -s -X POST http://localhost:8000/control -H "Content-Type: application/json" -H "Authorization: Bearer $ROVER_API_KEY" -d '{"command": {"linear": 0, "angular": 0}}'
 ```
 
 Take a photo and send it to the user:
 ```bash
-curl -s http://localhost:8000/v2/screenshot | jq -r '.front_frame' | base64 -d > front.png && echo "MEDIA:front.png"
+curl -s http://localhost:8000/v2/screenshot -H "Authorization: Bearer $ROVER_API_KEY" | jq -r '.front_frame' | base64 -d > front.png && echo "MEDIA:front.png"
 ```
 The `MEDIA:` prefix in the output triggers automatic image delivery to the user via Telegram. The file MUST be saved inside the workspace (not `/tmp/`). **NEVER describe the image in text.** Do NOT read the image and type what you see — the user wants the actual photo.
 
 Speak through the rover's speaker:
 ```bash
-curl -s -X POST http://localhost:8000/speak -H "Content-Type: application/json" -d '{"text": "hello"}'
+curl -s -X POST http://localhost:8000/speak -H "Content-Type: application/json" -H "Authorization: Bearer $ROVER_API_KEY" -d '{"text": "hello"}'
 ```
 
 Turn on lamp:
 ```bash
-curl -s -X POST http://localhost:8000/control -H "Content-Type: application/json" -d '{"command": {"linear": 0, "angular": 0, "lamp": 1}}'
+curl -s -X POST http://localhost:8000/control -H "Content-Type: application/json" -H "Authorization: Bearer $ROVER_API_KEY" -d '{"command": {"linear": 0, "angular": 0, "lamp": 1}}'
 ```
 
 Start mission:
 ```bash
-curl -s -X POST http://localhost:8000/start-mission
+curl -s -X POST http://localhost:8000/start-mission -H "Authorization: Bearer $ROVER_API_KEY"
 ```

--- a/examples/ros2/README.md
+++ b/examples/ros2/README.md
@@ -58,15 +58,16 @@ host networking doesn't reach the host's `localhost`.)
 
 ```bash
 hypercorn main:app
-curl -X POST http://localhost:8000/start-mission   # if MISSION_SLUG is set
+curl -X POST http://localhost:8000/start-mission -H "Authorization: Bearer $ROVER_API_KEY"   # if MISSION_SLUG is set
 ```
 
-2. Run the bridge:
+2. Run the bridge (every request needs the server's `ROVER_API_KEY`; the bridge reads it from the environment or the `rover_api_key` ROS param):
 
 ```bash
+export ROVER_API_KEY="<the key printed by the server on startup, or set in its .env>"
 python3 earth_rover_bridge.py
 # SDK on another machine:
-python3 earth_rover_bridge.py --ros-args -p sdk_url:=http://192.168.1.50:8000
+python3 earth_rover_bridge.py --ros-args -p sdk_url:=http://192.168.1.50:8000 -p rover_api_key:=$ROVER_API_KEY
 ```
 
 3. Drive and watch:
@@ -83,7 +84,9 @@ ros2 topic echo /earth_rover/gps
 
 ```python
 import cv2
-cap = cv2.VideoCapture("http://localhost:8000/feed?view=front&fps=15")
+# cv2.VideoCapture can't set custom headers, so pass the key as ?key= (the
+# server accepts either a header or a query param on GET endpoints).
+cap = cv2.VideoCapture("http://localhost:8000/feed?view=front&fps=15&key=YOUR_ROVER_API_KEY")
 while True:
     ok, frame = cap.read()
 ```

--- a/examples/ros2/README.md
+++ b/examples/ros2/README.md
@@ -85,7 +85,7 @@ ros2 topic echo /earth_rover/gps
 ```python
 import cv2
 # cv2.VideoCapture can't set custom headers, so pass the key as ?key= (the
-# server accepts either a header or a query param on GET endpoints).
+# server accepts query authentication only on the read-only /feed endpoint).
 cap = cv2.VideoCapture("http://localhost:8000/feed?view=front&fps=15&key=YOUR_ROVER_API_KEY")
 while True:
     ok, frame = cap.read()

--- a/examples/ros2/earth_rover_bridge.py
+++ b/examples/ros2/earth_rover_bridge.py
@@ -26,6 +26,7 @@ Dependencies (besides a ROS2 distro with rclpy + cv_bridge):
 
 import json
 import math
+import os
 import threading
 import time
 
@@ -82,7 +83,14 @@ class EarthRoverBridge(Node):
         self._cmd_lock = threading.Lock()
         self.create_subscription(Twist, "cmd_vel", self._on_cmd_vel, command_qos)
 
+        self.declare_parameter("rover_api_key", os.environ.get("ROVER_API_KEY", ""))
+        self.rover_api_key = self.get_parameter("rover_api_key").value
+
         self._session = requests.Session()
+        if self.rover_api_key:
+            self._session.headers.update(
+                {"Authorization": f"Bearer {self.rover_api_key}"}
+            )
         self._running = True
         self._stop_event = threading.Event()
         self._control_thread = threading.Thread(target=self._control_loop, daemon=True)
@@ -147,6 +155,10 @@ class EarthRoverBridge(Node):
 
     def _feed_loop(self):
         url = f"{self.sdk_url}/feed?view=front&fps={self.feed_fps}"
+        if self.rover_api_key:
+            # cv2.VideoCapture can't set custom headers, so the key rides
+            # along as a query param (the server accepts either for GET).
+            url += f"&key={self.rover_api_key}"
         while self._running and rclpy.ok():
             capture = cv2.VideoCapture(url)
             capture.set(cv2.CAP_PROP_BUFFERSIZE, 1)
@@ -172,6 +184,8 @@ class EarthRoverBridge(Node):
 
     def _telemetry_loop(self):
         ws_url = self.sdk_url.replace("http", "ws", 1) + "/ws/data"
+        if self.rover_api_key:
+            ws_url += f"?key={self.rover_api_key}"
         while self._running and rclpy.ok():
             ws = None
             try:

--- a/examples/ros2/er_poll_benchmark.py
+++ b/examples/ros2/er_poll_benchmark.py
@@ -37,6 +37,7 @@ Dependencies: rclpy + requests (both present in the ros:humble image).
 
 import base64
 import csv
+import os
 import threading
 import time
 
@@ -107,7 +108,12 @@ class ErPollBenchmark(Node):
         self.declare_parameter("use_session", True)
         self.declare_parameter("http_timeout_s", 10.0)
         self.declare_parameter("csv_path", "")
+        self.declare_parameter("rover_api_key", os.environ.get("ROVER_API_KEY", ""))
 
+        self.rover_api_key = self.get_parameter("rover_api_key").value
+        self._auth_headers = (
+            {"Authorization": f"Bearer {self.rover_api_key}"} if self.rover_api_key else {}
+        )
         self.sdk_url = self.get_parameter("sdk_url").value.rstrip("/")
         self.mode = self.get_parameter("mode").value
         self.rate_hz = float(self.get_parameter("rate_hz").value)
@@ -172,6 +178,8 @@ class ErPollBenchmark(Node):
         endpoint = "/v2/front" if self.mode == "v2_front" else "/v2/screenshot"
         url = self.sdk_url + endpoint
         http = requests.Session() if self.use_session else requests
+        if self.use_session:
+            http.headers.update(self._auth_headers)
         interval = 1.0 / self.rate_hz
         deadline = time.monotonic()
         while self._running and rclpy.ok():
@@ -179,7 +187,11 @@ class ErPollBenchmark(Node):
             status, frame_timestamp = "exc", None
             elapsed = 0.0
             try:
-                response = http.get(url, timeout=self.http_timeout_s)
+                response = http.get(
+                    url,
+                    timeout=self.http_timeout_s,
+                    headers=None if self.use_session else self._auth_headers,
+                )
                 status = str(response.status_code)
                 elapsed = time.monotonic() - started
                 if response.status_code == 200:
@@ -230,7 +242,10 @@ class ErPollBenchmark(Node):
         while self._running and rclpy.ok():
             try:
                 with requests.get(
-                    url, stream=True, timeout=(5, self.http_timeout_s)
+                    url,
+                    stream=True,
+                    timeout=(5, self.http_timeout_s),
+                    headers=self._auth_headers,
                 ) as response:
                     if response.status_code != 200:
                         self.stats.record_error(str(response.status_code))

--- a/examples/web/front_test.html
+++ b/examples/web/front_test.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+  Cross-origin: this page calls the SDK server directly, so it needs
+  ALLOWED_ORIGINS set on the server to this page's serving origin. Serve it
+  with a local static server (e.g. `python3 -m http.server 5500` from this
+  directory) rather than opening the file directly -- browsers send
+  `Origin: null` for file:// pages, which CORS allowlists can't reliably match.
+-->
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -24,11 +31,14 @@
     <img id="frontFrame" class="frame" alt="Front View" />
 
     <script>
+      const ROVER_API_KEY = ""; // paste your ROVER_API_KEY here
       const frontFrame = document.getElementById("frontFrame");
 
       const fetchFrontFrame = async () => {
         try {
-          const response = await fetch("http://localhost:8000/v2/front");
+          const response = await fetch("http://localhost:8000/v2/front", {
+            headers: { Authorization: "Bearer " + ROVER_API_KEY },
+          });
           const data = await response.json();
 
           frontFrame.src = `data:image/png;base64,${data.front_frame}`;

--- a/examples/web/intervention_manager.html
+++ b/examples/web/intervention_manager.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+  Cross-origin: this page calls the SDK server directly, so it needs
+  ALLOWED_ORIGINS set on the server to this page's serving origin. Serve it
+  with a local static server (e.g. `python3 -m http.server 5500` from this
+  directory) rather than opening the file directly -- browsers send
+  `Origin: null` for file:// pages, which CORS allowlists can't reliably match.
+-->
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -196,6 +203,7 @@
     </div>
 
     <script>
+      const ROVER_API_KEY = ""; // paste your ROVER_API_KEY here
       const startButton = document.getElementById("startButton");
       const endButton = document.getElementById("endButton");
       const messageDiv = document.getElementById("message");
@@ -217,7 +225,8 @@
       const updateInterventionsList = async () => {
         try {
           const response = await fetch(
-            "http://localhost:8000/interventions/history"
+            "http://localhost:8000/interventions/history",
+            { headers: { Authorization: "Bearer " + ROVER_API_KEY } }
           );
           const data = await response.json();
 
@@ -261,6 +270,7 @@
               method: "POST",
               headers: {
                 "Content-Type": "application/json",
+                Authorization: "Bearer " + ROVER_API_KEY,
               },
             }
           );
@@ -288,6 +298,7 @@
               method: "POST",
               headers: {
                 "Content-Type": "application/json",
+                Authorization: "Bearer " + ROVER_API_KEY,
               },
             }
           );

--- a/examples/web/rear_test.html
+++ b/examples/web/rear_test.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+  Cross-origin: this page calls the SDK server directly, so it needs
+  ALLOWED_ORIGINS set on the server to this page's serving origin. Serve it
+  with a local static server (e.g. `python3 -m http.server 5500` from this
+  directory) rather than opening the file directly -- browsers send
+  `Origin: null` for file:// pages, which CORS allowlists can't reliably match.
+-->
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -24,11 +31,14 @@
     <img id="rearFrame" class="frame" alt="Rear View" />
 
     <script>
+      const ROVER_API_KEY = ""; // paste your ROVER_API_KEY here
       const rearFrame = document.getElementById("rearFrame");
 
       const fetchRearFrame = async () => {
         try {
-          const response = await fetch("http://localhost:8000/v2/rear");
+          const response = await fetch("http://localhost:8000/v2/rear", {
+            headers: { Authorization: "Bearer " + ROVER_API_KEY },
+          });
           const data = await response.json();
           rearFrame.src = `data:image/png;base64,${data.rear_frame}`;
         } catch (error) {

--- a/examples/web/test_with_controls_mini.html
+++ b/examples/web/test_with_controls_mini.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+  Cross-origin: this page calls the SDK server directly, so it needs
+  ALLOWED_ORIGINS set on the server to this page's serving origin. Serve it
+  with a local static server (e.g. `python3 -m http.server 5500` from this
+  directory) rather than opening the file directly -- browsers send
+  `Origin: null` for file:// pages, which CORS allowlists can't reliably match.
+-->
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -254,6 +261,7 @@
     </div>
 
     <script>
+      const ROVER_API_KEY = ""; // paste your ROVER_API_KEY here
       const frontFrame = document.getElementById("frontFrame");
       const status = document.getElementById("status");
       const linearValue = document.getElementById("linearValue");
@@ -354,6 +362,7 @@
             method: "POST",
             headers: {
               "Content-Type": "application/json",
+              Authorization: "Bearer " + ROVER_API_KEY,
             },
             body: JSON.stringify({
               command: {
@@ -426,7 +435,9 @@
 
       const fetchFrontFrame = async () => {
         try {
-          const response = await fetch("http://localhost:8000/v2/front");
+          const response = await fetch("http://localhost:8000/v2/front", {
+            headers: { Authorization: "Bearer " + ROVER_API_KEY },
+          });
           const data = await response.json();
           frontFrame.src = `data:image/png;base64,${data.front_frame}`;
 

--- a/examples/web/test_with_controls_zero.html
+++ b/examples/web/test_with_controls_zero.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+  Cross-origin: this page calls the SDK server directly, so it needs
+  ALLOWED_ORIGINS set on the server to this page's serving origin. Serve it
+  with a local static server (e.g. `python3 -m http.server 5500` from this
+  directory) rather than opening the file directly -- browsers send
+  `Origin: null` for file:// pages, which CORS allowlists can't reliably match.
+-->
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -325,6 +332,7 @@
     </div>
 
     <script>
+      const ROVER_API_KEY = ""; // paste your ROVER_API_KEY here
       const frontFrame = document.getElementById("frontFrame");
       const rearFrame = document.getElementById("rearFrame");
       const status = document.getElementById("status");
@@ -433,6 +441,7 @@
             method: "POST",
             headers: {
               "Content-Type": "application/json",
+              Authorization: "Bearer " + ROVER_API_KEY,
             },
             body: JSON.stringify({
               command: {
@@ -512,7 +521,9 @@
 
       const fetchFrontFrame = async () => {
         try {
-          const response = await fetch("http://localhost:8000/v2/front");
+          const response = await fetch("http://localhost:8000/v2/front", {
+            headers: { Authorization: "Bearer " + ROVER_API_KEY },
+          });
           const data = await response.json();
           frontFrame.src = `data:image/png;base64,${data.front_frame}`;
 
@@ -532,7 +543,9 @@
 
       const fetchRearFrame = async () => {
         try {
-          const response = await fetch("http://localhost:8000/v2/rear");
+          const response = await fetch("http://localhost:8000/v2/rear", {
+            headers: { Authorization: "Bearer " + ROVER_API_KEY },
+          });
           const data = await response.json();
           rearFrame.src = `data:image/png;base64,${data.rear_frame}`;
 

--- a/examples/web/v2_visor.html
+++ b/examples/web/v2_visor.html
@@ -246,11 +246,9 @@
     <script>
       const $ = (id) => document.getElementById(id);
       const SLOW_MS = 250, TICKS = 120, SPARK = 300;
-      // Shared API key gate: sent as a header on plain fetch() calls, and as
-      // a ?key= query param for consumers that can't set headers (MJPEG
-      // <img>-style pulls, sendBeacon).
+      // Shared API key gate. State-changing requests always use a header;
+      // query-string credentials are reserved for the read-only MJPEG feed.
       const authHeaders = () => ($("key").value ? { Authorization: "Bearer " + $("key").value } : {});
-      const withKey = (url) => ($("key").value ? url + (url.includes("?") ? "&" : "?") + "key=" + encodeURIComponent($("key").value) : url);
 
       let running = false;
       let samples = [], history = [], lastTs = null, startedAt = 0;
@@ -594,12 +592,12 @@
       });
       // Never leave the last motion command active if the page goes away.
       window.addEventListener("pagehide", () => {
-        navigator.sendBeacon(
-          withKey($("url").value.replace(/\/+$/, "") + "/control"),
-          new Blob([JSON.stringify({ command: { linear: 0, angular: 0 } })], {
-            type: "application/json",
-          })
-        );
+        fetch($("url").value.replace(/\/+$/, "") + "/control", {
+          method: "POST",
+          headers: Object.assign({ "Content-Type": "application/json" }, authHeaders()),
+          body: JSON.stringify({ command: { linear: 0, angular: 0 } }),
+          keepalive: true,
+        }).catch(() => {});
       });
 
       // ---- server-side pipeline health via /status ------------------------

--- a/examples/web/v2_visor.html
+++ b/examples/web/v2_visor.html
@@ -1,4 +1,11 @@
 <!DOCTYPE html>
+<!--
+  Cross-origin: this page calls the SDK server directly, so it needs
+  ALLOWED_ORIGINS set on the server to this page's serving origin. Serve it
+  with a local static server (e.g. `python3 -m http.server 5500` from this
+  directory) rather than opening the file directly -- browsers send
+  `Origin: null` for file:// pages, which CORS allowlists can't reliably match.
+-->
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -156,6 +163,7 @@
 
     <div class="controls">
       <input id="url" value="http://localhost:8000" title="SDK base URL" />
+      <input id="key" value="" placeholder="ROVER_API_KEY" title="Shared API key (Authorization: Bearer ...)" />
       <select id="endpoint">
         <option value="/v2/front" selected>/v2/front</option>
         <option value="/v2/screenshot">/v2/screenshot</option>
@@ -238,6 +246,11 @@
     <script>
       const $ = (id) => document.getElementById(id);
       const SLOW_MS = 250, TICKS = 120, SPARK = 300;
+      // Shared API key gate: sent as a header on plain fetch() calls, and as
+      // a ?key= query param for consumers that can't set headers (MJPEG
+      // <img>-style pulls, sendBeacon).
+      const authHeaders = () => ($("key").value ? { Authorization: "Bearer " + $("key").value } : {});
+      const withKey = (url) => ($("key").value ? url + (url.includes("?") ? "&" : "?") + "key=" + encodeURIComponent($("key").value) : url);
 
       let running = false;
       let samples = [], history = [], lastTs = null, startedAt = 0;
@@ -327,7 +340,7 @@
       async function poll(base, endpoint) {
         const started = performance.now();
         try {
-          const res = await fetch(base + endpoint, { cache: "no-store" });
+          const res = await fetch(base + endpoint, { cache: "no-store", headers: authHeaders() });
           if (!running) return; // stopped while this poll was in flight
           const ms = performance.now() - started;
           if (!res.ok) {
@@ -426,7 +439,7 @@
           feedPrev = null;
           try {
             const res = await fetch(`${base}/feed?view=front&fps=${fps}`, {
-              signal: feedAbort.signal, cache: "no-store",
+              signal: feedAbort.signal, cache: "no-store", headers: authHeaders(),
             });
             if (!res.ok) throw new Error("HTTP " + res.status);
             $("dot").className = "dot live";
@@ -515,7 +528,7 @@
         try {
           const res = await fetch($("url").value.replace(/\/+$/, "") + "/control", {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
+            headers: Object.assign({ "Content-Type": "application/json" }, authHeaders()),
             body: JSON.stringify({ command }),
           });
           const ms = performance.now() - started;
@@ -582,7 +595,7 @@
       // Never leave the last motion command active if the page goes away.
       window.addEventListener("pagehide", () => {
         navigator.sendBeacon(
-          $("url").value.replace(/\/+$/, "") + "/control",
+          withKey($("url").value.replace(/\/+$/, "") + "/control"),
           new Blob([JSON.stringify({ command: { linear: 0, angular: 0 } })], {
             type: "application/json",
           })
@@ -596,7 +609,7 @@
       let statusTimer = null, lastStatusSample = null;
       async function pollStatus() {
         try {
-          const res = await fetch($("url").value.replace(/\/+$/, "") + "/status");
+          const res = await fetch($("url").value.replace(/\/+$/, "") + "/status", { headers: authHeaders() });
           const s = await res.json();
           if (!s.video) {
             $("srv-stats").textContent =

--- a/main.py
+++ b/main.py
@@ -12,7 +12,15 @@ import asyncio
 
 import aiohttp
 from dotenv import load_dotenv
-from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
+from fastapi import (
+    APIRouter,
+    Depends,
+    FastAPI,
+    HTTPException,
+    Request,
+    WebSocket,
+    WebSocketDisconnect,
+)
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
@@ -60,12 +68,24 @@ async def lifespan(app: FastAPI):
     await app.state.http_session.close()
 
 
-app = FastAPI(lifespan=lifespan)
+# No public API docs on a LAN rover server: /docs, /redoc and /openapi.json
+# would otherwise stay reachable without the API key.
+app = FastAPI(lifespan=lifespan, docs_url=None, redoc_url=None, openapi_url=None)
 
 
+# Cross-origin *browser* JS is denied by default: this server has no notion of
+# "known" origins (the dashboard is same-origin; every other consumer is a
+# non-browser HTTP client that CORS doesn't govern anyway). Set ALLOWED_ORIGINS
+# (comma-separated) only if a separately-hosted frontend needs cross-origin
+# fetch access.
+_allowed_origins = [
+    origin.strip()
+    for origin in os.getenv("ALLOWED_ORIGINS", "").split(",")
+    if origin.strip()
+]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=_allowed_origins,
     allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -88,6 +108,57 @@ checkpoints_list_data = {}
 auth_lock = None
 auth_lock_loop = None
 INGEST_TOKEN = secrets.token_urlsafe(32)
+
+# Every control/data/dashboard entry point requires this shared secret. If the
+# operator doesn't set one, generate a per-run key rather than defaulting to
+# open access, and log it so it can still be retrieved.
+_PLACEHOLDER_API_KEY = "change-me-to-a-long-random-value"
+ROVER_API_KEY = os.getenv("ROVER_API_KEY")
+if ROVER_API_KEY == _PLACEHOLDER_API_KEY:
+    raise SystemExit(
+        "ROVER_API_KEY is still set to the docker-compose.yml placeholder "
+        f'("{_PLACEHOLDER_API_KEY}") - set it to a real secret before starting.'
+    )
+if not ROVER_API_KEY:
+    ROVER_API_KEY = secrets.token_urlsafe(32)
+    logger.warning(
+        "ROVER_API_KEY not set - generated a key for this run (set ROVER_API_KEY "
+        "in the environment to keep it stable across restarts): %s",
+        ROVER_API_KEY,
+    )
+
+
+def _valid_api_key(supplied: str) -> bool:
+    return bool(supplied) and hmac.compare_digest(supplied, ROVER_API_KEY)
+
+
+def _key_from_query_or_cookie(request: Request) -> str:
+    """Shared by / and /sdk: the two routes a browser *navigates* to rather
+    than fetches, so neither can carry a custom header -- ?key= on first
+    load, the rover_key cookie (set by GET /) on every load after."""
+    return request.query_params.get("key") or request.cookies.get("rover_key", "")
+
+
+async def require_api_key(request: Request) -> None:
+    auth_header = request.headers.get("Authorization", "")
+    supplied = (
+        auth_header[len("Bearer ") :]
+        if auth_header[:7].lower() == "bearer "
+        else request.headers.get("X-API-Key", "")
+    )
+    # Fall back to ?key=, since some GET clients can't set custom headers
+    # (OpenCV's VideoCapture consuming /feed, a browser <img> tag, curl | ffmpeg).
+    if not supplied:
+        supplied = request.query_params.get("key", "")
+    if not _valid_api_key(supplied):
+        raise HTTPException(status_code=401, detail="Missing or invalid API key")
+
+
+# Every route below is protected by default (router-level dependency) so a new
+# endpoint can't ship open by forgetting a per-route Depends(). Only /, /sdk,
+# /static and the two WebSocket routes opt out below, each with its own
+# explicit check.
+router = APIRouter(dependencies=[Depends(require_api_key)])
 
 app.mount("/static", StaticFiles(directory="./static"), name="static")
 
@@ -169,7 +240,7 @@ async def latest_rover_data() -> dict:
     return await browser_service.data() or {}
 
 
-@app.get("/feed")
+@router.get("/feed")
 async def feed(view: str = "front", fps: int = 15):
     await need_start_mission()
     if not auth_response_data:
@@ -252,6 +323,13 @@ async def ws_ingest(websocket: WebSocket):
 
 @app.websocket("/ws/data")
 async def ws_data(websocket: WebSocket):
+    # Live telemetry (position, speed) for a real rover: gate it behind the
+    # same shared secret as everything else, as ?key= (same query param name
+    # as the rest of the API) since browser WebSocket clients can't set
+    # custom headers.
+    if not _valid_api_key(websocket.query_params.get("key", "")):
+        await websocket.close(code=4401)
+        return
     await websocket.accept()
     queue = telemetry_hub.subscribe()
     try:
@@ -268,7 +346,7 @@ async def ws_data(websocket: WebSocket):
         telemetry_hub.unsubscribe(queue)
 
 
-@app.get("/status")
+@router.get("/status")
 async def get_status():
     video = {
         view: {
@@ -420,8 +498,8 @@ async def need_start_mission():
     )
 
 
-@app.post("/checkpoints-list")
-@app.get("/checkpoints-list")
+@router.post("/checkpoints-list")
+@router.get("/checkpoints-list")
 async def checkpoints():
     await need_start_mission()
     await get_checkpoints_list()
@@ -478,7 +556,7 @@ async def auth():
     )
 
 
-@app.post("/start-mission")
+@router.post("/start-mission")
 async def start_mission():
     required_env_vars = ["SDK_API_TOKEN", "BOT_SLUG", "MISSION_SLUG"]
     missing_vars = [var for var in required_env_vars if not os.getenv(var)]
@@ -502,7 +580,7 @@ async def start_mission():
     )
 
 
-@app.post("/end-mission")
+@router.post("/end-mission")
 async def end_mission():
     required_env_vars = ["SDK_API_TOKEN", "BOT_SLUG", "MISSION_SLUG"]
     missing_vars = [var for var in required_env_vars if not os.getenv(var)]
@@ -589,6 +667,16 @@ async def render_index_html(is_spectator: bool):
 
 @app.get("/")
 async def get_index(request: Request):
+    supplied_key = _key_from_query_or_cookie(request)
+    if not _valid_api_key(supplied_key):
+        return HTMLResponse(
+            content=(
+                "<h1>Unauthorized</h1>"
+                "<p>Open this page with <code>?key=YOUR_ROVER_API_KEY</code>.</p>"
+            ),
+            status_code=401,
+        )
+
     # The dashboard renders even when the mission hasn't started or auth
     # fails — it degrades to "waiting" states instead of a raw JSON error.
     boot_notice = ""
@@ -614,19 +702,41 @@ async def get_index(request: Request):
         "missionSlug": os.getenv("MISSION_SLUG", ""),
         "missionStarted": bool(auth_response_data) or not os.getenv("MISSION_SLUG"),
         "bootNotice": str(boot_notice).replace("\n", " "),
+        "apiKey": supplied_key,
     }
     template_vars = {
         "dashboard_config": json.dumps(dashboard_config).replace("</", "<\\/")
     }
-    return render_template("dashboard.html", template_vars)
+    response = render_template("dashboard.html", template_vars)
+    # httponly: the page's own JS already gets the key from window.DASH.apiKey
+    # (templated server-side above) — the cookie only needs to survive reloads,
+    # not be readable by script.
+    response.set_cookie(
+        "rover_key",
+        supplied_key,
+        httponly=True,
+        samesite="lax",
+        secure=request.url.scheme == "https",
+        max_age=2592000,
+    )
+    return response
 
 
 @app.get("/sdk")
 async def sdk(request: Request):
+    supplied_key = _key_from_query_or_cookie(request)
+    if not _valid_api_key(supplied_key):
+        return HTMLResponse(
+            content=(
+                "<h1>Unauthorized</h1>"
+                "<p>Open this page with <code>?key=YOUR_ROVER_API_KEY</code>.</p>"
+            ),
+            status_code=401,
+        )
     return await render_index_html(is_spectator=False)
 
 
-@app.post("/control-legacy")
+@router.post("/control-legacy")
 async def control_legacy(request: Request):
     await need_start_mission()
     if not auth_response_data:
@@ -845,7 +955,7 @@ async def _control_watchdog(lamp, armed_at: float):
     await asyncio.shield(_ensure_confirmed_stop(lamp))
 
 
-@app.post("/control")
+@router.post("/control")
 async def control(request: Request):
     await need_start_mission()
     if not auth_response_data:
@@ -871,7 +981,7 @@ async def control(request: Request):
         raise HTTPException(status_code=500, detail=detail) from e
 
 
-@app.post("/speak")
+@router.post("/speak")
 async def speak(request: Request):
     await need_start_mission()
     if not auth_response_data:
@@ -893,7 +1003,7 @@ async def speak(request: Request):
         raise HTTPException(status_code=500, detail=f"TTS failed: {str(e)}") from e
 
 
-@app.get("/screenshot")
+@router.get("/screenshot")
 async def get_screenshot(view_types: str = "rear,map,front"):
     await need_start_mission()
     if not auth_response_data:
@@ -932,7 +1042,7 @@ async def get_screenshot(view_types: str = "rear,map,front"):
     return JSONResponse(content=response_content)
 
 
-@app.get("/data")
+@router.get("/data")
 async def get_data():
     await need_start_mission()
     # Fast path: fresh telemetry pushed by the /sdk page, no page.evaluate.
@@ -956,7 +1066,7 @@ def _pending_checkpoint_sequences() -> list[int]:
     return [sequence for sequence in sequences if sequence > latest]
 
 
-@app.post("/checkpoint-reached")
+@router.post("/checkpoint-reached")
 async def checkpoint_reached(request: Request):
     global auth_response_data, checkpoints_list_data
     await need_start_mission()
@@ -1055,7 +1165,7 @@ async def checkpoint_reached(request: Request):
     )
 
 
-@app.get("/missions-history")
+@router.get("/missions-history")
 async def missions_history():
     auth_header = os.getenv("SDK_API_TOKEN")
     bot_slug = os.getenv("BOT_SLUG")
@@ -1083,7 +1193,7 @@ async def missions_history():
     return JSONResponse(content=response_data)
 
 
-@app.get("/missions")
+@router.get("/missions")
 async def missions():
     auth_header = os.getenv("SDK_API_TOKEN")
     bot_slug = os.getenv("BOT_SLUG")
@@ -1121,7 +1231,7 @@ async def missions():
     return JSONResponse(content={"missions": missions_list})
 
 
-@app.get("/v2/screenshot")
+@router.get("/v2/screenshot")
 async def get_screenshot_v2():
     await need_start_mission()
     if not auth_response_data:
@@ -1160,7 +1270,7 @@ async def get_screenshot_v2():
     return JSONResponse(content=response_data)
 
 
-@app.get("/v2/front")
+@router.get("/v2/front")
 async def get_front_frame():
     await need_start_mission()
     if not auth_response_data:
@@ -1175,7 +1285,7 @@ async def get_front_frame():
         raise HTTPException(status_code=404, detail="Front frame not available")
 
 
-@app.get("/v2/rear")
+@router.get("/v2/rear")
 async def get_rear_frame():
     await need_start_mission()
     if not auth_response_data:
@@ -1193,7 +1303,7 @@ async def get_rear_frame():
         raise HTTPException(status_code=404, detail="Rear frame not available")
 
 
-@app.post("/interventions/start")
+@router.post("/interventions/start")
 async def start_intervention(request: Request):
     await need_start_mission()
 
@@ -1245,7 +1355,7 @@ async def start_intervention(request: Request):
     )
 
 
-@app.post("/interventions/end")
+@router.post("/interventions/end")
 async def end_intervention(request: Request):
     await need_start_mission()
 
@@ -1294,7 +1404,7 @@ async def end_intervention(request: Request):
     )
 
 
-@app.get("/interventions/history")
+@router.get("/interventions/history")
 async def interventions_history():
     auth_header = os.getenv("SDK_API_TOKEN")
     bot_slug = os.getenv("BOT_SLUG")
@@ -1325,3 +1435,6 @@ async def interventions_history():
             detail="Failed to retrieve interventions history",
         )
     return JSONResponse(content=response_data)
+
+
+app.include_router(router)

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ from fastapi import (
     WebSocketDisconnect,
 )
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
+from fastapi.responses import HTMLResponse, JSONResponse, Response, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from typing import Literal, Optional
 
@@ -83,6 +83,11 @@ _allowed_origins = [
     for origin in os.getenv("ALLOWED_ORIGINS", "").split(",")
     if origin.strip()
 ]
+if "*" in _allowed_origins or "null" in _allowed_origins:
+    raise SystemExit(
+        'ALLOWED_ORIGINS must list explicit trusted origins; "*" and "null" '
+        "are not allowed on a rover control server."
+    )
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_allowed_origins,
@@ -113,11 +118,20 @@ INGEST_TOKEN = secrets.token_urlsafe(32)
 # operator doesn't set one, generate a per-run key rather than defaulting to
 # open access, and log it so it can still be retrieved.
 _PLACEHOLDER_API_KEY = "change-me-to-a-long-random-value"
+_MIN_API_KEY_LENGTH = 32
 ROVER_API_KEY = os.getenv("ROVER_API_KEY")
 if ROVER_API_KEY == _PLACEHOLDER_API_KEY:
     raise SystemExit(
         "ROVER_API_KEY is still set to the docker-compose.yml placeholder "
         f'("{_PLACEHOLDER_API_KEY}") - set it to a real secret before starting.'
+    )
+if ROVER_API_KEY and (
+    len(ROVER_API_KEY) < _MIN_API_KEY_LENGTH or ROVER_API_KEY.strip() != ROVER_API_KEY
+):
+    raise SystemExit(
+        "ROVER_API_KEY must be at least 32 characters and must not have "
+        "leading or trailing whitespace. Generate one with: "
+        'python3 -c "import secrets; print(secrets.token_urlsafe(32))"'
     )
 if not ROVER_API_KEY:
     ROVER_API_KEY = secrets.token_urlsafe(32)
@@ -132,23 +146,29 @@ def _valid_api_key(supplied: str) -> bool:
     return bool(supplied) and hmac.compare_digest(supplied, ROVER_API_KEY)
 
 
-def _key_from_query_or_cookie(request: Request) -> str:
-    """Shared by / and /sdk: the two routes a browser *navigates* to rather
-    than fetches, so neither can carry a custom header -- ?key= on first
-    load, the rover_key cookie (set by GET /) on every load after."""
-    return request.query_params.get("key") or request.cookies.get("rover_key", "")
+def _key_from_headers(request: Request) -> str:
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header[:7].lower() == "bearer ":
+        return auth_header[len("Bearer ") :]
+    return request.headers.get("X-API-Key", "")
+
+
+def _key_from_browser_request(request: Request) -> str:
+    """Browser navigations can use the HttpOnly dashboard session cookie.
+
+    Machine-facing API routes deliberately do not accept this cookie, which
+    keeps a cross-site form or fetch from inheriting control authority.
+    """
+    return _key_from_headers(request) or request.cookies.get("rover_key", "")
 
 
 async def require_api_key(request: Request) -> None:
-    auth_header = request.headers.get("Authorization", "")
-    supplied = (
-        auth_header[len("Bearer ") :]
-        if auth_header[:7].lower() == "bearer "
-        else request.headers.get("X-API-Key", "")
-    )
-    # Fall back to ?key=, since some GET clients can't set custom headers
-    # (OpenCV's VideoCapture consuming /feed, a browser <img> tag, curl | ffmpeg).
-    if not supplied:
+    supplied = _key_from_headers(request)
+    # Only the read-only MJPEG feed accepts a query token. OpenCV's
+    # VideoCapture and browser <img> elements cannot set custom headers.
+    # Never accept query credentials on a state-changing route: CORS does not
+    # stop a malicious page from sending a simple no-cors POST.
+    if not supplied and request.method == "GET" and request.url.path == "/feed":
         supplied = request.query_params.get("key", "")
     if not _valid_api_key(supplied):
         raise HTTPException(status_code=401, detail="Missing or invalid API key")
@@ -157,7 +177,7 @@ async def require_api_key(request: Request) -> None:
 # Every route below is protected by default (router-level dependency) so a new
 # endpoint can't ship open by forgetting a per-route Depends(). Only /, /sdk,
 # /static and the two WebSocket routes opt out below, each with its own
-# explicit check.
+# explicit check. /session is the header-authenticated dashboard login.
 router = APIRouter(dependencies=[Depends(require_api_key)])
 
 app.mount("/static", StaticFiles(directory="./static"), name="static")
@@ -324,9 +344,8 @@ async def ws_ingest(websocket: WebSocket):
 @app.websocket("/ws/data")
 async def ws_data(websocket: WebSocket):
     # Live telemetry (position, speed) for a real rover: gate it behind the
-    # same shared secret as everything else, as ?key= (same query param name
-    # as the rest of the API) since browser WebSocket clients can't set
-    # custom headers.
+    # same shared secret as everything else, as ?key= since browser WebSocket
+    # clients can't set custom headers.
     if not _valid_api_key(websocket.query_params.get("key", "")):
         await websocket.close(code=4401)
         return
@@ -665,16 +684,75 @@ async def render_index_html(is_spectator: bool):
     return render_template("index.html", template_vars)
 
 
+_DASHBOARD_LOGIN_HTML = """<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Earth Rover SDK Login</title>
+  </head>
+  <body>
+    <main>
+      <h1>Earth Rover SDK</h1>
+      <p>Enter the ROVER_API_KEY configured for this server.</p>
+      <form id="login-form">
+        <label>API key <input id="api-key" type="password" autocomplete="current-password" required></label>
+        <button type="submit">Open dashboard</button>
+        <p id="login-error" role="alert"></p>
+      </form>
+    </main>
+    <script>
+      document.getElementById("login-form").addEventListener("submit", async function (event) {
+        event.preventDefault();
+        var key = document.getElementById("api-key").value;
+        var response = await fetch("/session", {
+          method: "POST",
+          headers: { Authorization: "Bearer " + key }
+        });
+        if (response.ok) location.replace("/");
+        else document.getElementById("login-error").textContent = "Invalid API key";
+      });
+    </script>
+  </body>
+</html>
+"""
+
+
+def _harden_browser_response(response: Response) -> Response:
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["Referrer-Policy"] = "no-referrer"
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    return response
+
+
+def _set_dashboard_cookie(response: Response, request: Request, key: str) -> None:
+    response.set_cookie(
+        "rover_key",
+        key,
+        httponly=True,
+        samesite="strict",
+        secure=request.url.scheme == "https",
+        max_age=2592000,
+        path="/",
+    )
+
+
+@app.post("/session")
+async def create_dashboard_session(request: Request):
+    supplied_key = _key_from_headers(request)
+    if not _valid_api_key(supplied_key):
+        raise HTTPException(status_code=401, detail="Missing or invalid API key")
+    response = Response(status_code=204)
+    _set_dashboard_cookie(response, request, supplied_key)
+    return _harden_browser_response(response)
+
+
 @app.get("/")
 async def get_index(request: Request):
-    supplied_key = _key_from_query_or_cookie(request)
+    supplied_key = _key_from_browser_request(request)
     if not _valid_api_key(supplied_key):
-        return HTMLResponse(
-            content=(
-                "<h1>Unauthorized</h1>"
-                "<p>Open this page with <code>?key=YOUR_ROVER_API_KEY</code>.</p>"
-            ),
-            status_code=401,
+        return _harden_browser_response(
+            HTMLResponse(content=_DASHBOARD_LOGIN_HTML, status_code=401)
         )
 
     # The dashboard renders even when the mission hasn't started or auth
@@ -708,32 +786,20 @@ async def get_index(request: Request):
         "dashboard_config": json.dumps(dashboard_config).replace("</", "<\\/")
     }
     response = render_template("dashboard.html", template_vars)
-    # httponly: the page's own JS already gets the key from window.DASH.apiKey
-    # (templated server-side above) — the cookie only needs to survive reloads,
-    # not be readable by script.
-    response.set_cookie(
-        "rover_key",
-        supplied_key,
-        httponly=True,
-        samesite="lax",
-        secure=request.url.scheme == "https",
-        max_age=2592000,
-    )
-    return response
+    # The cookie only authenticates browser navigations. API requests still
+    # carry an explicit header, so cross-site requests cannot inherit control.
+    _set_dashboard_cookie(response, request, supplied_key)
+    return _harden_browser_response(response)
 
 
 @app.get("/sdk")
 async def sdk(request: Request):
-    supplied_key = _key_from_query_or_cookie(request)
+    supplied_key = _key_from_browser_request(request)
     if not _valid_api_key(supplied_key):
-        return HTMLResponse(
-            content=(
-                "<h1>Unauthorized</h1>"
-                "<p>Open this page with <code>?key=YOUR_ROVER_API_KEY</code>.</p>"
-            ),
-            status_code=401,
+        return _harden_browser_response(
+            HTMLResponse(content="<h1>Unauthorized</h1>", status_code=401)
         )
-    return await render_index_html(is_spectator=False)
+    return _harden_browser_response(await render_index_html(is_spectator=False))
 
 
 @router.post("/control-legacy")

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -7,6 +7,15 @@
     return document.getElementById(id);
   };
 
+  // Every same-origin API call this page makes needs the shared secret this
+  // page itself was loaded with (see GET / in main.py).
+  var AUTH_HEADER = { Authorization: "Bearer " + (DASH.apiKey || "") };
+  function apiFetch(url, opts) {
+    opts = opts || {};
+    opts.headers = Object.assign({}, AUTH_HEADER, opts.headers || {});
+    return fetch(url, opts);
+  }
+
   /* ---------- Header / mission lifecycle ---------- */
 
   if (DASH.botSlug) $("bot-chip").textContent = DASH.botSlug;
@@ -105,17 +114,17 @@
     var request;
     if (stopping) {
       // Dispatch a confirmed zero command before ending the remote ride.
-      request = fetch("/control", {
+      request = apiFetch("/control", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ command: { linear: 0, angular: 0 } }),
       })
         .catch(function () {})
         .then(function () {
-          return fetch("/end-mission", { method: "POST" });
+          return apiFetch("/end-mission", { method: "POST" });
         });
     } else {
-      request = fetch("/start-mission", { method: "POST" });
+      request = apiFetch("/start-mission", { method: "POST" });
     }
 
     request
@@ -132,6 +141,13 @@
   });
 
   renderMissionAction();
+
+  // Plain <a> navigation, not fetch — these bypass apiFetch's Authorization
+  // header entirely, so they need the key riding in the URL instead.
+  ["footer-data", "footer-status"].forEach(function (id) {
+    var link = $(id);
+    if (link && DASH.apiKey) link.href += "?key=" + encodeURIComponent(DASH.apiKey);
+  });
 
   if (!missionStarted) {
     document.querySelectorAll(".pad, #lamp-btn, #speak-btn, #checkpoint-btn").forEach(function (control) {
@@ -325,7 +341,8 @@
     ws = new WebSocket(
       (location.protocol === "https:" ? "wss://" : "ws://") +
         location.host +
-        "/ws/data"
+        "/ws/data?key=" +
+        encodeURIComponent(DASH.apiKey || "")
     );
     ws.onopen = function () {
       setLed("led-telemetry", "on");
@@ -368,7 +385,7 @@
   });
 
   // One initial fetch so the page isn't blank while real time is off.
-  fetch("/data")
+  apiFetch("/data")
     .then(function (r) {
       return r.ok ? r.json() : null;
     })
@@ -379,7 +396,7 @@
 
   // Light status poll for the rover LED (works with real time off).
   function pollStatus() {
-    fetch("/status")
+    apiFetch("/status")
       .then(function (r) {
         return r.ok ? r.json() : null;
       })
@@ -442,7 +459,7 @@
     var command = pendingCommand;
     pendingCommand = null;
     commandInFlight = true;
-    fetch("/control", {
+    apiFetch("/control", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ command: command }),
@@ -604,7 +621,7 @@
     var btn = $("speak-btn");
     btn.disabled = true;
     btn.textContent = "Sending…";
-    fetch("/speak", {
+    apiFetch("/speak", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ text: text }),
@@ -654,7 +671,7 @@
     $("active-mission-slug").textContent = DASH.missionSlug || "mission";
     renderCheckpoints(null);
 
-    fetch("/checkpoints-list")
+    apiFetch("/checkpoints-list")
       .then(function (r) {
         return r.ok ? r.json() : null;
       })
@@ -700,7 +717,7 @@
     tabsLoaded.available = true;
     var list = $("available-list");
     list.innerHTML = '<p class="empty">Loading missions…</p>';
-    fetch("/missions")
+    apiFetch("/missions")
       .then(function (r) {
         if (!r.ok) throw new Error("HTTP " + r.status);
         return r.json();
@@ -744,7 +761,7 @@
     tabsLoaded.history = true;
     var list = $("history-list");
     list.innerHTML = '<p class="empty">Loading history…</p>';
-    fetch("/missions-history")
+    apiFetch("/missions-history")
       .then(function (r) {
         if (!r.ok) throw new Error("HTTP " + r.status);
         return r.json();
@@ -856,7 +873,7 @@
   $("checkpoint-btn").addEventListener("click", function () {
     var btn = this;
     btn.disabled = true;
-    fetch("/checkpoint-reached", { method: "POST" })
+    apiFetch("/checkpoint-reached", { method: "POST" })
       .then(function (r) {
         return r.json().then(function (body) {
           if (!r.ok) {

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -142,13 +142,6 @@
 
   renderMissionAction();
 
-  // Plain <a> navigation, not fetch — these bypass apiFetch's Authorization
-  // header entirely, so they need the key riding in the URL instead.
-  ["footer-data", "footer-status"].forEach(function (id) {
-    var link = $(id);
-    if (link && DASH.apiKey) link.href += "?key=" + encodeURIComponent(DASH.apiKey);
-  });
-
   if (!missionStarted) {
     document.querySelectorAll(".pad, #lamp-btn, #speak-btn, #checkpoint-btn").forEach(function (control) {
       control.disabled = true;

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 from playwright.async_api import Error as PlaywrightError
 
@@ -30,6 +31,17 @@ class FakeBrowser:
 
 
 class BrowserRecoveryTest(unittest.IsolatedAsyncioTestCase):
+    def test_sdk_page_url_strips_legacy_query_key(self):
+        service = BrowserService()
+        with patch(
+            "browser_service.SDK_PAGE_URL",
+            "http://127.0.0.1:8000/sdk?mode=drive&key=do-not-log-this",
+        ):
+            self.assertEqual(
+                service._sdk_page_url(),
+                "http://127.0.0.1:8000/sdk?mode=drive",
+            )
+
     async def test_stale_failure_cannot_destroy_new_generation(self):
         service = BrowserService()
         stale = FakePage(closed=True)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,225 @@
+import os
+from pathlib import Path
+import subprocess
+import sys
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from fastapi import HTTPException, Request
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+import main
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class QueryAuthenticationScopeTest(unittest.IsolatedAsyncioTestCase):
+    @staticmethod
+    def request(method, path):
+        return Request(
+            {
+                "type": "http",
+                "http_version": "1.1",
+                "method": method,
+                "scheme": "http",
+                "path": path,
+                "raw_path": path.encode(),
+                "query_string": f"key={main.ROVER_API_KEY}".encode(),
+                "headers": [],
+                "client": ("127.0.0.1", 12345),
+                "server": ("127.0.0.1", 8000),
+            }
+        )
+
+    async def test_query_key_is_limited_to_read_only_feed(self):
+        await main.require_api_key(self.request("GET", "/feed"))
+
+        for method, path in (("GET", "/status"), ("POST", "/control")):
+            with self.subTest(method=method, path=path):
+                with self.assertRaises(HTTPException) as context:
+                    await main.require_api_key(self.request(method, path))
+                self.assertEqual(context.exception.status_code, 401)
+
+
+class ControlAuthenticationTest(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(main.app)
+        main.auth_response_data = {"BOT_UID": "test-bot"}
+        main.cancel_control_watchdog()
+
+    def tearDown(self):
+        main.cancel_control_watchdog()
+        main.auth_response_data = {}
+        self.client.close()
+
+    @staticmethod
+    def command():
+        return {"command": {"linear": 0, "angular": 0}}
+
+    def test_control_routes_reject_missing_and_invalid_keys(self):
+        for path in ("/control", "/control-legacy"):
+            with self.subTest(path=path, credential="missing"):
+                response = self.client.post(path, json=self.command())
+                self.assertEqual(response.status_code, 401)
+            with self.subTest(path=path, credential="invalid"):
+                response = self.client.post(
+                    path,
+                    headers={"Authorization": "Bearer invalid"},
+                    json=self.command(),
+                )
+                self.assertEqual(response.status_code, 401)
+
+    def test_control_routes_accept_header_credentials(self):
+        auth = {"Authorization": f"Bearer {main.ROVER_API_KEY}"}
+        with (
+            patch.object(main, "need_start_mission", AsyncMock()),
+            patch.object(main, "_dispatch_browser_control", AsyncMock()),
+            patch.object(main, "_dispatch_legacy_control", AsyncMock()),
+        ):
+            self.assertEqual(
+                self.client.post(
+                    "/control", headers=auth, json=self.command()
+                ).status_code,
+                200,
+            )
+            self.assertEqual(
+                self.client.post(
+                    "/control-legacy",
+                    headers={"X-API-Key": main.ROVER_API_KEY},
+                    json=self.command(),
+                ).status_code,
+                200,
+            )
+
+    def test_query_key_cannot_authorize_malicious_cross_origin_post(self):
+        dispatch = AsyncMock()
+        with (
+            patch.object(main, "need_start_mission", AsyncMock()),
+            patch.object(main, "_dispatch_browser_control", dispatch),
+        ):
+            response = self.client.post(
+                f"/control?key={main.ROVER_API_KEY}",
+                headers={
+                    "Origin": "https://evil.example",
+                    "Content-Type": "text/plain",
+                },
+                content='{"command":{"linear":1,"angular":0}}',
+            )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertNotIn("access-control-allow-origin", response.headers)
+        dispatch.assert_not_awaited()
+
+    def test_default_cors_rejects_untrusted_preflight(self):
+        response = self.client.options(
+            "/control",
+            headers={
+                "Origin": "https://evil.example",
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Headers": "authorization,content-type",
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertNotIn("access-control-allow-origin", response.headers)
+
+    def test_websocket_rejects_missing_key(self):
+        with self.assertRaises(WebSocketDisconnect) as context:
+            with self.client.websocket_connect("/ws/data"):
+                pass
+        self.assertEqual(context.exception.code, 4401)
+
+
+class DashboardAuthenticationTest(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(main.app)
+
+    def tearDown(self):
+        self.client.close()
+
+    def test_dashboard_query_key_is_rejected_and_login_does_not_cache(self):
+        response = self.client.get(f"/?key={main.ROVER_API_KEY}")
+        self.assertEqual(response.status_code, 401)
+        self.assertIn("ROVER_API_KEY", response.text)
+        self.assertEqual(response.headers["cache-control"], "no-store")
+        self.assertEqual(response.headers["referrer-policy"], "no-referrer")
+
+    def test_header_login_sets_hardened_cookie_and_opens_dashboard(self):
+        response = self.client.post(
+            "/session",
+            headers={"Authorization": f"Bearer {main.ROVER_API_KEY}"},
+        )
+        self.assertEqual(response.status_code, 204)
+        cookie = response.headers["set-cookie"].lower()
+        self.assertIn("httponly", cookie)
+        self.assertIn("samesite=strict", cookie)
+        self.assertIn("path=/", cookie)
+
+        with patch.object(main, "auth_response_data", {"BOT_UID": "test-bot"}):
+            dashboard = self.client.get("/")
+        self.assertEqual(dashboard.status_code, 200)
+        self.assertNotIn("?key=", dashboard.text)
+        self.assertEqual(dashboard.headers["cache-control"], "no-store")
+
+    def test_api_routes_do_not_accept_dashboard_cookie(self):
+        self.client.cookies.set("rover_key", main.ROVER_API_KEY)
+        response = self.client.post("/control", json={"command": {"linear": 0}})
+        self.assertEqual(response.status_code, 401)
+
+
+class SecurityConfigurationTest(unittest.TestCase):
+    def run_import(self, **environment):
+        child_environment = os.environ.copy()
+        child_environment.update(environment)
+        return subprocess.run(
+            [sys.executable, "-c", "import main"],
+            cwd=REPO_ROOT,
+            env=child_environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_short_configured_key_is_rejected(self):
+        result = self.run_import(ROVER_API_KEY="too-short")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("at least 32 characters", result.stderr)
+
+    def test_wildcard_cors_origin_is_rejected(self):
+        result = self.run_import(
+            ROVER_API_KEY="a-secure-random-key-with-32-characters",
+            ALLOWED_ORIGINS="*",
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("explicit trusted origins", result.stderr)
+
+    def test_docker_defaults_are_loopback_only(self):
+        dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
+        compose = (REPO_ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+        self.assertIn("${ROVER_BIND_HOST:-127.0.0.1}:8000", dockerfile)
+        self.assertIn('"127.0.0.1:8000:8000"', compose)
+
+
+class BasicExampleClientTest(unittest.TestCase):
+    def test_shared_client_adds_bearer_header(self):
+        basics_path = REPO_ROOT / "examples" / "basics"
+        sys.path.insert(0, str(basics_path))
+        try:
+            import _client
+
+            with patch.dict(os.environ, {"ROVER_API_KEY": main.ROVER_API_KEY}):
+                session = _client.rover_session()
+            try:
+                self.assertEqual(
+                    session.headers["Authorization"],
+                    f"Bearer {main.ROVER_API_KEY}",
+                )
+            finally:
+                session.close()
+        finally:
+            sys.path.remove(str(basics_path))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Locks down the SDK HTTP server so a rover is not remotely controllable without a strong shared credential and is not exposed to the LAN by default.

- State-changing API routes, including /control and /control-legacy, require Authorization: Bearer ROVER_API_KEY or X-API-Key. Query credentials are rejected on POST routes, preventing malicious no-CORS browser requests.
- Query authentication is limited to the read-only /feed endpoint and /ws/data, whose clients cannot always set headers.
- The dashboard uses a header-authenticated login and an HttpOnly SameSite=Strict cookie. The key is no longer placed in dashboard URLs, browser history, referers, or access-log request paths.
- Docker binds to loopback by default. Compose publishes 127.0.0.1:8000 and LAN exposure requires explicit configuration.
- CORS defaults to no origins; wildcard and null origins are rejected.
- Explicit ROVER_API_KEY values must be at least 32 characters. The Docker placeholder is rejected; an unset key is securely generated for local use.
- API docs remain disabled. Updated Python, ROS2, browser, dashboard, benchmark, and OpenClaw clients authenticate correctly.
- Adds the missing basic-example client helper and security regression tests covering both control endpoints, malicious-origin POSTs, CORS, WebSocket auth, dashboard-cookie isolation, configuration strength, and Docker exposure defaults.

Verification: 55 unit/security tests pass, Ruff passes, docker compose config validates.