### PR TITLE
v6.3: surface real backend errors to callers and in DEBUG

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,7 +680,8 @@ Example Response:
 
 - v.6.3:
 
-  - Backend errors are no longer swallowed while debugging: with `DEBUG=true`, any non-2xx response from the FrodoBots API is logged with its real status and body, so a failed `/start-mission` shows the actual reason (e.g. `Bot is currently in use by another user`) instead of only the generic `Bot unavailable for SDK`
+  - The real backend error is now returned to the caller: `/start-mission` and the other API-backed endpoints surface the actual reason (e.g. `Bot is currently in use by another user`) in the response `detail` instead of the generic `Bot unavailable for SDK`, so it's clear why a mission couldn't start
+  - Backend errors are also no longer swallowed while debugging: with `DEBUG=true`, any non-2xx response from the FrodoBots API is logged with its real status and body
 
 - v.6.2:
 

--- a/README.md
+++ b/README.md
@@ -680,8 +680,8 @@ Example Response:
 
 - v.6.3:
 
-  - The real backend error is now returned to the caller: `/start-mission` and the other API-backed endpoints surface the actual reason (e.g. `Bot is currently in use by another user`) in the response `detail` instead of the generic `Bot unavailable for SDK`, so it's clear why a mission couldn't start
-  - Backend errors are also no longer swallowed while debugging: with `DEBUG=true`, any non-2xx response from the FrodoBots API is logged with its real status and body
+  - Backend errors are no longer swallowed while debugging. With `DEBUG=true`, any non-2xx response from the FrodoBots API is logged with its real status and body, and the actual reason (e.g. `Bot is currently in use by another user`) is returned to the caller in the response `detail` instead of the generic `Bot unavailable for SDK`
+  - In normal operation (`DEBUG` unset) the generic message is kept, so backend internals are never exposed to arbitrary callers
 
 - v.6.2:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <br>
 </p>
 
-# Earth Rovers SDK v6.2
+# Earth Rovers SDK v6.3
 
 ## Requirements
 
@@ -677,6 +677,10 @@ Example Response:
 ```
 
 # Latest updates
+
+- v.6.3:
+
+  - Backend errors are no longer swallowed while debugging: with `DEBUG=true`, any non-2xx response from the FrodoBots API is logged with its real status and body, so a failed `/start-mission` shows the actual reason (e.g. `Bot is currently in use by another user`) instead of only the generic `Bot unavailable for SDK`
 
 - v.6.2:
 

--- a/main.py
+++ b/main.py
@@ -104,13 +104,23 @@ async def external_request(method: str, url: str, **kwargs) -> tuple[int, dict]:
     """Use pooled async HTTP so rover hot paths never block the event loop."""
 
     async def perform(session: aiohttp.ClientSession):
-        if os.getenv("DEBUG") == "true":
+        debug = os.getenv("DEBUG") == "true"
+        if debug:
             logger.info("External %s %s", method.upper(), url)
         async with session.request(method, url, **kwargs) as response:
             try:
                 body = await response.json(content_type=None)
             except (aiohttp.ContentTypeError, json.JSONDecodeError):
                 body = {"error": await response.text()}
+
+            if debug and response.status >= 400:
+                logger.error(
+                    "External %s %s failed: %s %s",
+                    method.upper(),
+                    url,
+                    response.status,
+                    body,
+                )
             return response.status, body
 
     try:

--- a/main.py
+++ b/main.py
@@ -381,6 +381,17 @@ def get_env_tokens():
     return None
 
 
+def _backend_error_detail(response_data, fallback):
+    """Prefer the backend's own error message so the caller sees the real reason
+    (e.g. "Bot is currently in use by another user") instead of a generic one.
+    Falls back when the body has no plain-text error."""
+    if isinstance(response_data, dict):
+        message = response_data.get("error") or response_data.get("detail")
+        if isinstance(message, str) and message.strip():
+            return message
+    return fallback
+
+
 async def start_ride(headers, bot_slug, mission_slug):
     start_ride_data = {"bot_slug": bot_slug, "mission_slug": mission_slug}
     status, response_data = await external_request(
@@ -392,7 +403,7 @@ async def start_ride(headers, bot_slug, mission_slug):
     if status != 200:
         raise HTTPException(
             status_code=status,
-            detail="Bot unavailable for SDK",
+            detail=_backend_error_detail(response_data, "Bot unavailable for SDK"),
         )
     return response_data
 
@@ -406,7 +417,10 @@ async def end_ride(headers, bot_slug, mission_slug):
         json=end_ride_data,
     )
     if status != 200:
-        raise HTTPException(status_code=status, detail="Failed to end mission")
+        raise HTTPException(
+            status_code=status,
+            detail=_backend_error_detail(response_data, "Failed to end mission"),
+        )
     return response_data
 
 
@@ -416,7 +430,10 @@ async def retrieve_tokens(headers, bot_slug):
         "POST", FRODOBOTS_API_URL + "/sdk/token", headers=headers, json=data
     )
     if status != 200:
-        raise HTTPException(status_code=status, detail="Failed to retrieve tokens")
+        raise HTTPException(
+            status_code=status,
+            detail=_backend_error_detail(response_data, "Failed to retrieve tokens"),
+        )
     return response_data
 
 

--- a/main.py
+++ b/main.py
@@ -382,9 +382,12 @@ def get_env_tokens():
 
 
 def _backend_error_detail(response_data, fallback):
-    """Prefer the backend's own error message so the caller sees the real reason
-    (e.g. "Bot is currently in use by another user") instead of a generic one.
-    Falls back when the body has no plain-text error."""
+    """With DEBUG=true, surface the backend's own error message so a developer
+    sees the real reason (e.g. "Bot is currently in use by another user").
+    In normal operation return only the generic fallback, so backend internals
+    are never exposed to arbitrary callers."""
+    if os.getenv("DEBUG") != "true":
+        return fallback
     if isinstance(response_data, dict):
         message = response_data.get("error") or response_data.get("detail")
         if isinstance(message, str) and message.strip():

--- a/tests/test_external_request.py
+++ b/tests/test_external_request.py
@@ -1,0 +1,83 @@
+import json
+import os
+import unittest
+from unittest.mock import patch
+
+import main
+
+
+class _FakeResponse:
+    def __init__(self, status, body):
+        self.status = status
+        self._body = body
+
+    async def json(self, content_type=None):
+        return self._body
+
+    async def text(self):
+        return json.dumps(self._body)
+
+
+class _FakeRequestContextManager:
+    def __init__(self, response):
+        self._response = response
+
+    async def __aenter__(self):
+        return self._response
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    closed = False
+
+    def __init__(self, response):
+        self._response = response
+        self.last_request = None
+
+    def request(self, method, url, **kwargs):
+        self.last_request = (method, url, kwargs)
+        return _FakeRequestContextManager(self._response)
+
+
+class ExternalRequestTest(unittest.IsolatedAsyncioTestCase):
+    async def _call(self, status, body, debug):
+        session = _FakeSession(_FakeResponse(status, body))
+        env = {"DEBUG": "true"} if debug else {"DEBUG": "false"}
+        with patch.dict(os.environ, env), \
+                patch.object(main.app.state, "http_session", session, create=True), \
+                patch.object(main, "logger") as mock_logger:
+            result = await main.external_request("POST", "http://api/sdk/start_ride")
+        return result, mock_logger
+
+    async def test_returns_backend_status_and_body(self):
+        error_body = {"error": "Bot is currently in use by another user"}
+        (status, body), _ = await self._call(403, error_body, debug=False)
+
+        self.assertEqual(status, 403)
+        self.assertEqual(body, error_body)
+
+    async def test_logs_real_backend_error_in_debug(self):
+        error_body = {"error": "Bot is currently in use by another user"}
+        _, mock_logger = await self._call(403, error_body, debug=True)
+
+        mock_logger.error.assert_called_once()
+        logged = str(mock_logger.error.call_args)
+        self.assertIn("Bot is currently in use by another user", logged)
+        self.assertIn("403", logged)
+
+    async def test_does_not_log_error_without_debug(self):
+        error_body = {"error": "Bot is currently in use by another user"}
+        _, mock_logger = await self._call(403, error_body, debug=False)
+
+        mock_logger.error.assert_not_called()
+
+    async def test_does_not_log_error_on_success(self):
+        _, mock_logger = await self._call(200, {"CHANNEL_NAME": "ride_1"}, debug=True)
+
+        mock_logger.error.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_external_request.py
+++ b/tests/test_external_request.py
@@ -79,5 +79,28 @@ class ExternalRequestTest(unittest.IsolatedAsyncioTestCase):
         mock_logger.error.assert_not_called()
 
 
+class BackendErrorDetailTest(unittest.TestCase):
+    def test_uses_backend_error_message(self):
+        detail = main._backend_error_detail(
+            {"error": "Bot is currently in use by another user"}, "fallback"
+        )
+        self.assertEqual(detail, "Bot is currently in use by another user")
+
+    def test_uses_backend_detail_message(self):
+        detail = main._backend_error_detail({"detail": "Mission not found"}, "fallback")
+        self.assertEqual(detail, "Mission not found")
+
+    def test_falls_back_when_no_message(self):
+        self.assertEqual(main._backend_error_detail({}, "fallback"), "fallback")
+        self.assertEqual(main._backend_error_detail(None, "fallback"), "fallback")
+
+    def test_falls_back_when_error_is_not_a_plain_string(self):
+        detail = main._backend_error_detail({"error": {"mission": ["blank"]}}, "fallback")
+        self.assertEqual(detail, "fallback")
+
+    def test_falls_back_when_error_is_blank(self):
+        self.assertEqual(main._backend_error_detail({"error": "  "}, "fallback"), "fallback")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_external_request.py
+++ b/tests/test_external_request.py
@@ -80,26 +80,33 @@ class ExternalRequestTest(unittest.IsolatedAsyncioTestCase):
 
 
 class BackendErrorDetailTest(unittest.TestCase):
-    def test_uses_backend_error_message(self):
-        detail = main._backend_error_detail(
-            {"error": "Bot is currently in use by another user"}, "fallback"
-        )
+    def _detail(self, response_data, fallback="fallback", debug=True):
+        env = {"DEBUG": "true"} if debug else {"DEBUG": "false"}
+        with patch.dict(os.environ, env):
+            return main._backend_error_detail(response_data, fallback)
+
+    def test_uses_backend_error_message_in_debug(self):
+        detail = self._detail({"error": "Bot is currently in use by another user"})
         self.assertEqual(detail, "Bot is currently in use by another user")
 
-    def test_uses_backend_detail_message(self):
-        detail = main._backend_error_detail({"detail": "Mission not found"}, "fallback")
-        self.assertEqual(detail, "Mission not found")
+    def test_uses_backend_detail_message_in_debug(self):
+        self.assertEqual(self._detail({"detail": "Mission not found"}), "Mission not found")
 
-    def test_falls_back_when_no_message(self):
-        self.assertEqual(main._backend_error_detail({}, "fallback"), "fallback")
-        self.assertEqual(main._backend_error_detail(None, "fallback"), "fallback")
-
-    def test_falls_back_when_error_is_not_a_plain_string(self):
-        detail = main._backend_error_detail({"error": {"mission": ["blank"]}}, "fallback")
+    def test_hides_backend_message_without_debug(self):
+        detail = self._detail(
+            {"error": "Bot is currently in use by another user"}, debug=False
+        )
         self.assertEqual(detail, "fallback")
 
+    def test_falls_back_when_no_message(self):
+        self.assertEqual(self._detail({}), "fallback")
+        self.assertEqual(self._detail(None), "fallback")
+
+    def test_falls_back_when_error_is_not_a_plain_string(self):
+        self.assertEqual(self._detail({"error": {"mission": ["blank"]}}), "fallback")
+
     def test_falls_back_when_error_is_blank(self):
-        self.assertEqual(main._backend_error_detail({"error": "  "}, "fallback"), "fallback")
+        self.assertEqual(self._detail({"error": "  "}), "fallback")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

When a call to the FrodoBots API fails, the SDK collapses any non-200 into a **generic** `HTTPException` detail and throws the real body away. Starting a mission on a bot that's in use surfaces only:

```
Bot unavailable for SDK
```

...when the backend actually returned `403 {"error": "Bot is currently in use by another user"}`. Developers had no way to see the real reason.

## Fix (all gated behind `DEBUG=true`)

**1. Log the real error in DEBUG.** `external_request` — the single choke point every backend call flows through — logs the actual status and body at `error` level when `DEBUG=true`:

```
ERROR http_logger External POST .../sdk/start_ride failed: 403 {'error': 'Bot is currently in use by another user'}
```

**2. Return the real reason to the caller, in DEBUG only.** `start_ride`, `end_ride`, and `retrieve_tokens` pass the backend's own message into the `HTTPException` detail via `_backend_error_detail` — **but only when `DEBUG=true`**. In normal operation the generic fallback is kept, so backend internals are never exposed to arbitrary callers.

- `DEBUG=true` → `{ "detail": "Bot is currently in use by another user" }`
- `DEBUG` unset → `{ "detail": "Bot unavailable for SDK" }` (unchanged)

## Tests

`tests/test_external_request.py` (new): DEBUG logging (logs real error / silent without DEBUG / silent on 2xx) and `_backend_error_detail` (surfaces `error`/`detail` in DEBUG, hides it without DEBUG, falls back on empty/non-string bodies). Full suite green.

Bumps the SDK to **v6.3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)