### PR TITLE
Dashboard + curated SDK error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,6 +682,7 @@ Example Response:
 
   - Backend errors are no longer swallowed while debugging. With `DEBUG=true`, any non-2xx response from the FrodoBots API is logged with its real status and body, and the actual reason (e.g. `Bot is currently in use by another user`) is returned to the caller in the response `detail` instead of the generic `Bot unavailable for SDK`
   - In normal operation (`DEBUG` unset) the generic message is kept, so backend internals are never exposed to arbitrary callers
+  - Dashboard: when a session can't start, the video panel shows the real reason (e.g. `Bot status is invalid.`, or the generic `Bot unavailable for SDK`) instead of the vague "Video unavailable / No spectator token configured for this session"
 
 - v.6.2:
 

--- a/README.md
+++ b/README.md
@@ -680,9 +680,9 @@ Example Response:
 
 - v.6.3:
 
-  - Backend errors are no longer swallowed while debugging. With `DEBUG=true`, any non-2xx response from the FrodoBots API is logged with its real status and body, and the actual reason (e.g. `Bot is currently in use by another user`) is returned to the caller in the response `detail` instead of the generic `Bot unavailable for SDK`
-  - In normal operation (`DEBUG` unset) the generic message is kept, so backend internals are never exposed to arbitrary callers
-  - Dashboard: when a session can't start, the video panel shows the real reason (e.g. `Bot status is invalid.`, or the generic `Bot unavailable for SDK`) instead of the vague "Video unavailable / No spectator token configured for this session"
+  - Clearer, safe error messages when a session can't start. Known backend failures map to fixed, user-facing messages — `401` → `User not found` (bad SDK API key), `403` → `Bot unavailable for SDK` (bot in use) — and anything else falls back to a generic message. The mapping is keyed on the HTTP status, never the raw backend body, so backend internals are never exposed
+  - With `DEBUG=true`, the real backend status and body are still logged server-side to help diagnose the underlying failure
+  - Dashboard: when a session can't start, the video panel shows that message (e.g. `Bot unavailable for SDK`) instead of the vague "Video unavailable / No spectator token configured for this session"
 
 - v.6.2:
 

--- a/README.md
+++ b/README.md
@@ -682,7 +682,7 @@ Example Response:
 
   - Clearer, safe error messages when a session can't start. Known backend failures map to fixed, user-facing messages — `401` → `User not found` (bad SDK API key), `403` → `Bot unavailable for SDK` (bot in use) — and anything else falls back to a generic message. The mapping is keyed on the HTTP status, never the raw backend body, so backend internals are never exposed
   - With `DEBUG=true`, the real backend status and body are still logged server-side to help diagnose the underlying failure
-  - Dashboard: when a session can't start, the video panel shows that message (e.g. `Bot unavailable for SDK`) instead of the vague "Video unavailable / No spectator token configured for this session"
+  - Dashboard: when a session can't start, the video panel shows that message (e.g. `Bot unavailable for SDK`) instead of the vague "Video unavailable / No spectator token configured for this session". When the bot is in use, the hint reads "Another user is using this bot — try again shortly." rather than the misleading "Fix the issue and try again."
 
 - v.6.2:
 

--- a/main.py
+++ b/main.py
@@ -381,17 +381,17 @@ def get_env_tokens():
     return None
 
 
-def _backend_error_detail(response_data, fallback):
-    """With DEBUG=true, surface the backend's own error message so a developer
-    sees the real reason (e.g. "Bot is currently in use by another user").
-    In normal operation return only the generic fallback, so backend internals
-    are never exposed to arbitrary callers."""
-    if os.getenv("DEBUG") != "true":
-        return fallback
-    if isinstance(response_data, dict):
-        message = response_data.get("error") or response_data.get("detail")
-        if isinstance(message, str) and message.strip():
-            return message
+def _sdk_error_detail(status, fallback):
+    """Map known backend failures to safe, user-facing messages. Keyed off the
+    HTTP status (not the raw body), so backend internals are never exposed and
+    the message stays stable if the backend rewords its errors.
+      401 -> the SDK API key didn't resolve to a user
+      403 -> the bot is in use / not permitted for SDK
+      other -> the caller's generic fallback"""
+    if status == 401:
+        return "User not found"
+    if status == 403:
+        return "Bot unavailable for SDK"
     return fallback
 
 
@@ -406,7 +406,7 @@ async def start_ride(headers, bot_slug, mission_slug):
     if status != 200:
         raise HTTPException(
             status_code=status,
-            detail=_backend_error_detail(response_data, "Bot unavailable for SDK"),
+            detail=_sdk_error_detail(status, "Bot unavailable for SDK"),
         )
     return response_data
 
@@ -422,7 +422,7 @@ async def end_ride(headers, bot_slug, mission_slug):
     if status != 200:
         raise HTTPException(
             status_code=status,
-            detail=_backend_error_detail(response_data, "Failed to end mission"),
+            detail=_sdk_error_detail(status, "Failed to end mission"),
         )
     return response_data
 
@@ -435,7 +435,7 @@ async def retrieve_tokens(headers, bot_slug):
     if status != 200:
         raise HTTPException(
             status_code=status,
-            detail=_backend_error_detail(response_data, "Failed to retrieve tokens"),
+            detail=_sdk_error_detail(status, "Bot unavailable for SDK"),
         )
     return response_data
 

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -910,10 +910,15 @@
 
   function initVideo() {
     if (!DASH.appid || !DASH.rtcToken) {
-      if (missionStarted) {
-        setPlaceholder("Video unavailable", {
+      if (DASH.bootNotice && !/start-mission/i.test(DASH.bootNotice)) {
+        // Auth/token failed (e.g. the bot is in use or its status is invalid).
+        // Keep the real reason instead of overwriting it with a generic
+        // "Video unavailable" message.
+        reportProblem(DASH.bootNotice, true);
+      } else if (missionStarted) {
+        setPlaceholder("Bot unavailable for SDK", {
           tone: "warn",
-          sub: "No spectator token configured for this session.",
+          sub: "Couldn't get a video feed for this session — the bot may be offline or in use.",
         });
       }
       // Not started: the placeholder already shows the mission empty state.

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -37,6 +37,16 @@
     return $("front-placeholder").classList.contains("hidden");
   }
 
+  // Guidance under an error title. "Fix the issue and try again" is wrong when
+  // nothing on this side can be fixed (e.g. someone else is driving the bot),
+  // so map those cases to a "wait" message.
+  function problemSubtitle(message) {
+    if (message === "Bot unavailable for SDK") {
+      return "Another user is using this bot — try again shortly.";
+    }
+    return "Fix the issue and try again.";
+  }
+
   // Problems go where the user is looking: big and centered when the video
   // area is empty, a slim overlay strip when video is playing.
   function reportProblem(message, isError) {
@@ -46,7 +56,7 @@
       showBootNotice("", false);
       setPlaceholder(message, {
         tone: isError ? "error" : "warn",
-        sub: isError ? "Fix the issue and try again." : "",
+        sub: isError ? problemSubtitle(message) : "",
         startButton: !missionStarted && !!DASH.missionSlug,
       });
     }

--- a/tests/test_external_request.py
+++ b/tests/test_external_request.py
@@ -79,34 +79,23 @@ class ExternalRequestTest(unittest.IsolatedAsyncioTestCase):
         mock_logger.error.assert_not_called()
 
 
-class BackendErrorDetailTest(unittest.TestCase):
-    def _detail(self, response_data, fallback="fallback", debug=True):
-        env = {"DEBUG": "true"} if debug else {"DEBUG": "false"}
-        with patch.dict(os.environ, env):
-            return main._backend_error_detail(response_data, fallback)
+class SdkErrorDetailTest(unittest.TestCase):
+    def test_maps_401_to_user_not_found(self):
+        self.assertEqual(main._sdk_error_detail(401, "fallback"), "User not found")
 
-    def test_uses_backend_error_message_in_debug(self):
-        detail = self._detail({"error": "Bot is currently in use by another user"})
-        self.assertEqual(detail, "Bot is currently in use by another user")
-
-    def test_uses_backend_detail_message_in_debug(self):
-        self.assertEqual(self._detail({"detail": "Mission not found"}), "Mission not found")
-
-    def test_hides_backend_message_without_debug(self):
-        detail = self._detail(
-            {"error": "Bot is currently in use by another user"}, debug=False
+    def test_maps_403_to_bot_unavailable(self):
+        self.assertEqual(
+            main._sdk_error_detail(403, "fallback"), "Bot unavailable for SDK"
         )
-        self.assertEqual(detail, "fallback")
 
-    def test_falls_back_when_no_message(self):
-        self.assertEqual(self._detail({}), "fallback")
-        self.assertEqual(self._detail(None), "fallback")
+    def test_uses_fallback_for_other_statuses(self):
+        self.assertEqual(main._sdk_error_detail(422, "fallback"), "fallback")
+        self.assertEqual(main._sdk_error_detail(404, "fallback"), "fallback")
+        self.assertEqual(main._sdk_error_detail(500, "fallback"), "fallback")
 
-    def test_falls_back_when_error_is_not_a_plain_string(self):
-        self.assertEqual(self._detail({"error": {"mission": ["blank"]}}), "fallback")
-
-    def test_falls_back_when_error_is_blank(self):
-        self.assertEqual(self._detail({"error": "  "}), "fallback")
+    def test_never_returns_raw_backend_text(self):
+        # The mapping is keyed on status only, so backend internals can't leak.
+        self.assertEqual(main._sdk_error_detail(422, "generic"), "generic")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

When a session can't start, the SDK surfaced unhelpful messages:
- The dashboard video panel showed **"Video unavailable / No spectator token configured for this session"** — `initVideo()` ran last and overwrote the real reason.
- The API detail was either a bland generic ("Bot unavailable for SDK") or, in v6.3, the **raw backend body gated behind `DEBUG`** — which risked leaking backend internals.

## Fix

**Curated, safe error messages** (`_sdk_error_detail`), keyed on the HTTP **status** — never the raw backend body, so nothing internal leaks and the wording is stable if the backend rewords its errors:

| Backend | Cause | User sees |
|---|---|---|
| `401` | bad / missing SDK API key | **User not found** |
| `403` | bot in use (our reject) | **Bot unavailable for SDK** |
| anything else | mission not found, bot status, 5xx… | **generic fallback** |

- Replaces v6.3's `DEBUG`-gated raw propagation. The `DEBUG=true` server-side log of the real status + body is kept for diagnosis.
- **Dashboard**: `initVideo()` no longer clobbers the real reason with "Video unavailable" — it shows the curated message (via `bootNotice`), so the page and the API agree.

## Tests

`tests/test_external_request.py`: `_sdk_error_detail` maps 401/403 and falls back for others (and never returns raw backend text); the DEBUG-logging tests are unchanged. Full suite green. Dashboard JS verified with `node --check` (no JS test harness in this repo).

## Notes

- `retrieve_tokens`' generic fallback changed from "Failed to retrieve tokens" to "Bot unavailable for SDK" (the token path is the connect path, so bot-availability wording reads better on the dashboard).
- 401 uses **"User not found"** (the backend's own phrasing); trivial to switch to "Invalid SDK API key" if preferred.
- Separate, still-open: the `/sdk/token` **retry storm** (pollers re-auth every ~2s with no backoff) — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)