### PR TITLE
Keep dashboard mission progress in sync

### DIFF
--- a/main.py
+++ b/main.py
@@ -85,6 +85,7 @@ V2_FRAME_TIMEOUT_S = float(os.getenv("V2_FRAME_TIMEOUT_S", "2"))
 # In-memory storage for the response
 auth_response_data = {}
 checkpoints_list_data = {}
+mission_completion_data = None
 auth_lock = None
 auth_lock_loop = None
 INGEST_TOKEN = secrets.token_urlsafe(32)
@@ -303,6 +304,49 @@ async def get_status():
     )
 
 
+def _mission_progress_snapshot() -> dict:
+    """Return local mission progress without another backend request."""
+    sequences = sorted(
+        cp.get("sequence")
+        for cp in checkpoints_list_data.get("checkpoints_list", [])
+        if isinstance(cp.get("sequence"), int)
+    )
+    latest = checkpoints_list_data.get("latest_scanned_checkpoint")
+
+    if mission_completion_data is not None:
+        latest = mission_completion_data.get("latest_scanned_checkpoint")
+
+    try:
+        latest_number = int(latest) if latest is not None else 0
+    except (TypeError, ValueError):
+        latest_number = 0
+    next_sequence = next(
+        (sequence for sequence in sequences if sequence > latest_number), None
+    )
+
+    return {
+        "mission_started": bool(auth_response_data)
+        or not os.getenv("MISSION_SLUG"),
+        "mission_completed": mission_completion_data is not None,
+        "latest_scanned_checkpoint": latest,
+        "next_checkpoint_sequence": None
+        if mission_completion_data is not None
+        else next_sequence,
+    }
+
+
+def _publish_mission_progress():
+    telemetry_hub.broadcast(
+        {"type": "mission_progress", "data": _mission_progress_snapshot()}
+    )
+
+
+@app.get("/mission-progress")
+async def get_mission_progress():
+    """Cheap polling endpoint for dashboards watching external controllers."""
+    return JSONResponse(content=_mission_progress_snapshot())
+
+
 async def auth_common():
     global auth_lock, auth_lock_loop, auth_response_data
     if auth_response_data:
@@ -510,6 +554,7 @@ async def auth():
 
 @app.post("/start-mission")
 async def start_mission():
+    global mission_completion_data
     required_env_vars = ["SDK_API_TOKEN", "BOT_SLUG", "MISSION_SLUG"]
     missing_vars = [var for var in required_env_vars if not os.getenv(var)]
 
@@ -523,6 +568,8 @@ async def start_mission():
         await auth()
     if not checkpoints_list_data:
         await get_checkpoints_list()
+    mission_completion_data = None
+    _publish_mission_progress()
     return JSONResponse(
         status_code=200,
         content={
@@ -560,9 +607,11 @@ async def end_mission():
         await end_ride(headers, bot_slug, mission_slug)
         cancel_control_watchdog()
         # Clear the stored auth and checkpoints data
-        global auth_response_data, checkpoints_list_data
+        global auth_response_data, checkpoints_list_data, mission_completion_data
         auth_response_data = {}
         checkpoints_list_data = {}
+        mission_completion_data = None
+        _publish_mission_progress()
         await asyncio.gather(
             *(broadcaster.close() for broadcaster in feed_broadcasters.values())
         )
@@ -988,7 +1037,7 @@ def _pending_checkpoint_sequences() -> list[int]:
 
 @app.post("/checkpoint-reached")
 async def checkpoint_reached(request: Request):
-    global auth_response_data, checkpoints_list_data
+    global auth_response_data, checkpoints_list_data, mission_completion_data
     await need_start_mission()
 
     bot_slug = os.getenv("BOT_SLUG")
@@ -1062,6 +1111,9 @@ async def checkpoint_reached(request: Request):
         checkpoints_list_data["latest_scanned_checkpoint"] = pending_sequences[0]
 
     if mission_completed:
+        mission_completion_data = {
+            "latest_scanned_checkpoint": max(sequences) if sequences else None,
+        }
         # The backend ends the ride after the last checkpoint, which kills
         # the feed and makes the bot unreachable. Drop the local session so
         # /status reports it and /start-mission re-authenticates cleanly.
@@ -1070,10 +1122,13 @@ async def checkpoint_reached(request: Request):
         cancel_control_watchdog()
         auth_response_data = {}
         checkpoints_list_data = {}
+        _publish_mission_progress()
         await asyncio.gather(
             *(broadcaster.close() for broadcaster in feed_broadcasters.values())
         )
         await browser_service.close()
+    else:
+        _publish_mission_progress()
 
     return JSONResponse(
         status_code=200,

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -350,6 +350,9 @@
       if (msg.type === "snapshot" || msg.type === "telemetry") {
         if (msg.data) renderTelemetry(msg.data);
       }
+      if (msg.type === "mission_progress") {
+        applyMissionProgress(msg.data);
+      }
       if (msg.ingest_connected !== undefined) {
         setLed("led-rover", msg.ingest_connected ? "on" : "off");
       }
@@ -659,25 +662,43 @@
 
   /* --- Active mission tab --- */
 
+  var missionProgressTimer = null;
+
+  function applyMissionProgress(progress) {
+    if (!progress) return;
+    if (progress.mission_completed) {
+      if (missionStarted) missionCompleted();
+      return;
+    }
+
+    var nextSequence = progress.next_checkpoint_sequence;
+    if (
+      (nextSequence === null || nextSequence === undefined) &&
+      progress.latest_scanned_checkpoint !== null &&
+      progress.latest_scanned_checkpoint !== undefined
+    ) {
+      nextSequence = parseInt(progress.latest_scanned_checkpoint, 10) + 1;
+    }
+    if (nextSequence !== null && nextSequence !== undefined) {
+      renderCheckpoints(parseInt(nextSequence, 10));
+    }
+  }
+
+  function pollMissionProgress() {
+    fetch("/mission-progress")
+      .then(function (r) {
+        return r.ok ? r.json() : null;
+      })
+      .then(applyMissionProgress)
+      .catch(function () {});
+  }
+
   if (checkpoints.length > 0) {
     $("active-mission-head").classList.remove("hidden");
     $("active-mission-slug").textContent = DASH.missionSlug || "mission";
     renderCheckpoints(null);
-
-    fetch("/checkpoints-list")
-      .then(function (r) {
-        return r.ok ? r.json() : null;
-      })
-      .then(function (body) {
-        if (
-          body &&
-          body.latest_scanned_checkpoint !== null &&
-          body.latest_scanned_checkpoint !== undefined
-        ) {
-          renderCheckpoints(parseInt(body.latest_scanned_checkpoint, 10) + 1);
-        }
-      })
-      .catch(function () {});
+    pollMissionProgress();
+    missionProgressTimer = setInterval(pollMissionProgress, 1000);
   } else {
     $("active-empty").classList.remove("hidden");
     $("checkpoint-btn").classList.add("hidden");
@@ -838,6 +859,8 @@
   // drops and the bot stops listening. Reflect that instead of erroring.
   function missionCompleted() {
     missionStarted = false;
+    clearInterval(missionProgressTimer);
+    missionProgressTimer = null;
     clearDriveState();
     document
       .querySelectorAll(".pad, #lamp-btn, #speak-btn, #checkpoint-btn")

--- a/tests/test_control_watchdog.py
+++ b/tests/test_control_watchdog.py
@@ -176,6 +176,7 @@ class CheckpointSafetyTest(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         main.cancel_control_watchdog()
         main.auth_response_data = {"BOT_UID": "bot"}
+        main.mission_completion_data = None
         main.checkpoints_list_data = {
             "checkpoints_list": [
                 {"sequence": 1},
@@ -189,6 +190,7 @@ class CheckpointSafetyTest(unittest.IsolatedAsyncioTestCase):
         main.cancel_control_watchdog()
         main.auth_response_data = {}
         main.checkpoints_list_data = {}
+        main.mission_completion_data = None
 
     async def test_final_checkpoint_confirms_stop_before_backend_teardown(self):
         order = []
@@ -218,6 +220,15 @@ class CheckpointSafetyTest(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(order, ["stop", "checkpoint"])
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            main._mission_progress_snapshot(),
+            {
+                "mission_started": False,
+                "mission_completed": True,
+                "latest_scanned_checkpoint": 3,
+                "next_checkpoint_sequence": None,
+            },
+        )
 
     async def test_final_checkpoint_is_not_reported_without_confirmed_stop(self):
         external = AsyncMock()
@@ -270,6 +281,11 @@ class CheckpointSafetyTest(unittest.IsolatedAsyncioTestCase):
             main.checkpoints_list_data["latest_scanned_checkpoint"], 2
         )
         self.assertEqual(response.status_code, 200)
+        progress = main._mission_progress_snapshot()
+        self.assertTrue(progress["mission_started"])
+        self.assertFalse(progress["mission_completed"])
+        self.assertEqual(progress["latest_scanned_checkpoint"], 2)
+        self.assertEqual(progress["next_checkpoint_sequence"], 3)
 
 
 if __name__ == "__main__":

--- a/tests/test_main_concurrency.py
+++ b/tests/test_main_concurrency.py
@@ -24,6 +24,7 @@ class MainConcurrencyTest(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         main.auth_response_data = {}
         main.checkpoints_list_data = {}
+        main.mission_completion_data = None
         main.auth_lock = None
         main.auth_lock_loop = None
 
@@ -111,6 +112,30 @@ class MainConcurrencyTest(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(feed.unsubscribed)
         self.assertIs(feed.assert_queue, feed.queue)
+
+    async def test_mission_progress_endpoint_uses_local_cache(self):
+        main.auth_response_data = TOKENS.copy()
+        main.checkpoints_list_data = {
+            "checkpoints_list": [
+                {"sequence": 1},
+                {"sequence": 2},
+                {"sequence": 3},
+            ],
+            "latest_scanned_checkpoint": 1,
+        }
+
+        with patch.dict(os.environ, {"MISSION_SLUG": "mission"}):
+            response = await main.get_mission_progress()
+
+        self.assertEqual(
+            json.loads(response.body),
+            {
+                "mission_started": True,
+                "mission_completed": False,
+                "latest_scanned_checkpoint": 1,
+                "next_checkpoint_sequence": 2,
+            },
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expose cached mission progress through a lightweight endpoint
- broadcast checkpoint and completion updates over the existing WebSocket
- poll once per second as a fallback so externally reported checkpoints refresh the dashboard
- preserve final completion state and add regression coverage

## Validation
- python -m unittest discover -s tests (50 tests)
- node --check static/dashboard.js
- git diff --check